### PR TITLE
Case insensitive should in example_wording.rb

### DIFF
--- a/lib/rubocop/cop/rspec/example_wording.rb
+++ b/lib/rubocop/cop/rspec/example_wording.rb
@@ -28,7 +28,7 @@ module RuboCop
 
           arguments = *(args.first)
           message = arguments.first.to_s
-          return unless message.start_with?('should')
+          return unless message.start_with?('should', 'Should')
 
           arg1 = args.first.loc.expression
           message = Parser::Source::Range

--- a/spec/rubocop/cop/rspec/example_wording_spec.rb
+++ b/spec/rubocop/cop/rspec/example_wording_spec.rb
@@ -18,6 +18,16 @@ describe RuboCop::Cop::RSpec::ExampleWording, :config do
     expect(cop.highlights).to eq(['should do something'])
   end
 
+  it 'finds description with `Should` at the beginning' do
+    inspect_source(cop, ["it 'Should do something' do", 'end'])
+    expect(cop.offenses.size).to eq(1)
+    expect(cop.offenses.map(&:line).sort).to eq([1])
+    expect(cop.messages)
+      .to eq(['Do not use should when describing your tests.'])
+    expect(cop.highlights).to eq(['Should do something'])
+  end
+
+
   it 'finds description with `shouldn\'t` at the beginning' do
     inspect_source(cop, ['it "shouldn\'t do something" do', 'end'])
     expect(cop.offenses.size).to eq(1)

--- a/spec/rubocop/cop/rspec/example_wording_spec.rb
+++ b/spec/rubocop/cop/rspec/example_wording_spec.rb
@@ -27,7 +27,6 @@ describe RuboCop::Cop::RSpec::ExampleWording, :config do
     expect(cop.highlights).to eq(['Should do something'])
   end
 
-
   it 'finds description with `shouldn\'t` at the beginning' do
     inspect_source(cop, ['it "shouldn\'t do something" do', 'end'])
     expect(cop.offenses.size).to eq(1)


### PR DESCRIPTION
example wording cop now also looks for should when spelled with an capital S. 

Closes #30.

