### PR TITLE
Ignore cops in some spec types

### DIFF
--- a/lib/rubocop/cop/rspec/describe_class.rb
+++ b/lib/rubocop/cop/rspec/describe_class.rb
@@ -21,8 +21,25 @@ module RuboCop
                   'module being tested.'
 
         def on_top_level_describe(_node, args)
-          return if args.first && args.first.type == :const
-          add_offense(args.first, :expression, MESSAGE)
+          return if args[0] && args[0].type == :const
+
+          return if request_spec?(args[1]) || feature_spec?(args[1])
+
+          add_offense(args[0], :expression, MESSAGE)
+        end
+
+        private
+
+        def request_spec?(node)
+          return false unless node
+
+          node.loc.expression.source == 'type: :request' || ':type => :request'
+        end
+
+        def feature_spec?(node)
+          return false unless node
+
+          node.loc.expression.source == 'type: :feature' || ':type => :feature'
         end
       end
     end

--- a/lib/rubocop/cop/rspec/describe_method.rb
+++ b/lib/rubocop/cop/rspec/describe_method.rb
@@ -26,7 +26,7 @@ module RuboCop
 
         def on_top_level_describe(_node, args)
           second_arg = args[1]
-          return unless second_arg
+          return unless second_arg && second_arg.type == :str
           return if METHOD_STRING_MATCHER =~ second_arg.children.first
 
           add_offense(second_arg, :expression, MESSAGE)

--- a/lib/rubocop/cop/rspec/file_path.rb
+++ b/lib/rubocop/cop/rspec/file_path.rb
@@ -25,7 +25,10 @@ module RuboCop
           object = const_name(args.first)
           return unless object
 
-          path_matcher = matcher(object, args[1])
+          method = args[1]
+          return unless method.nil? || method.type == :str
+
+          path_matcher = matcher(object, method)
           return if source_filename =~ regexp_from_glob(path_matcher)
 
           add_offense(node, :expression, format(MESSAGE, path_matcher))

--- a/lib/rubocop/rspec/top_level_describe.rb
+++ b/lib/rubocop/rspec/top_level_describe.rb
@@ -9,8 +9,6 @@ module RuboCop
         return unless top_level_describe?(node)
 
         _receiver, _method_name, *args = *node
-        # Ignore non-string args (RSpec metadata)
-        args = [args.first] + args[1..-1].select { |a| a.type == :str }
 
         on_top_level_describe(node, args)
       end

--- a/spec/rubocop/cop/rspec/describe_class_spec.rb
+++ b/spec/rubocop/cop/rspec/describe_class_spec.rb
@@ -27,6 +27,16 @@ describe RuboCop::Cop::RSpec::DescribeClass do
     expect(cop.offenses).to be_empty
   end
 
+  it 'ignores request specs' do
+    inspect_source(cop, "describe 'my new feature', type: :request do; end")
+    expect(cop.offenses).to be_empty
+  end
+
+  it 'ignores feature specs' do
+    inspect_source(cop, "describe 'my new feature', type: :feature do; end")
+    expect(cop.offenses).to be_empty
+  end
+
   it "doesn't blow up on single-line describes" do
     inspect_source(cop, 'describe Some::Class')
     expect(cop.offenses).to be_empty

--- a/spec/rubocop/cop/rspec/describe_method_spec.rb
+++ b/spec/rubocop/cop/rspec/describe_method_spec.rb
@@ -17,4 +17,10 @@ describe RuboCop::Cop::RSpec::DescribeMethod do
                          "describe Some::Class, '#fdsa' do; end"])
     expect(cop.offenses).to be_empty
   end
+
+  it 'skips specs not having a string second argument' do
+    inspect_source(cop, 'describe Some::Class, :config do; end')
+
+    expect(cop.offenses).to be_empty
+  end
 end

--- a/spec/rubocop/cop/rspec/file_path_spec.rb
+++ b/spec/rubocop/cop/rspec/file_path_spec.rb
@@ -49,6 +49,12 @@ describe RuboCop::Cop::RSpec::FilePath, :config do
     expect(cop.offenses).to be_empty
   end
 
+  it 'skips specs not having a string second argument' do
+    inspect_source(cop, 'describe Some::Class, :config do; end')
+
+    expect(cop.offenses).to be_empty
+  end
+
   it 'checks class specs' do
     inspect_source(cop,
                    'describe Some::Class do; end',


### PR DESCRIPTION
Hi!

I was getting offenses from the `DescribeClass` cop when running RSpec request specs which I think does not make sense. So I've prepared a PR to skip the cop for those spec types.

While developing the patch I found a similar issue when RSpec tagged specs would get a `DescribeMethod` offense. So I skipped that cop as well in those cases.