### PR TITLE
Fix the build with a shallow clone of RuboCop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,5 @@ pkg
 
 # For rubinius:
 #*.rbc
+
+/vendor

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ matrix:
   allow_failures:
     - rvm: ruby-head
     - rvm: rbx-2
-before_install: gem update --remote bundler
+before_install:
+ - gem update --remote bundler
+ - git clone --depth 1 git://github.com/bbatsov/rubocop.git vendor/rubocop
 script:
   - bundle exec rake

--- a/README.md
+++ b/README.md
@@ -72,6 +72,22 @@ RSpec/FilePath:
 ```
 
 
+## Contributing
+
+1. Fork it
+2. Create your feature branch (`git checkout -b my-new-feature`)
+3. Commit your changes (`git commit -am 'Add some feature'`)
+4. Push to the branch (`git push origin my-new-feature`)
+5. Create new Pull Request
+
+For running the spec files, this project depends on RuboCop's spec helpers.
+This means that in order to run the specs locally, you need a (shallow) clone
+of the RuboCop repository:
+
+```bash
+git clone --depth 1 git://github.com/bbatsov/rubocop.git vendor/rubocop
+```
+
 ## License
 
 `rubocop-rspec` is MIT licensed. [See the accompanying file](MIT-LICENSE.md) for

--- a/lib/rubocop/cop/rspec/described_class.rb
+++ b/lib/rubocop/cop/rspec/described_class.rb
@@ -34,7 +34,7 @@ module RuboCop
         end
 
         def autocorrect(node)
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             corrector.replace(node.loc.expression, 'described_class')
           end
         end

--- a/lib/rubocop/cop/rspec/example_wording.rb
+++ b/lib/rubocop/cop/rspec/example_wording.rb
@@ -21,7 +21,7 @@ module RuboCop
         MSG = 'Do not use should when describing your tests.'
 
         def on_block(node) # rubocop:disable Metrics/AbcSize
-          method, _, _ = *node
+          method, = *node
           _, method_name, *args = *method
 
           return unless method_name == :it

--- a/lib/rubocop/cop/rspec/example_wording.rb
+++ b/lib/rubocop/cop/rspec/example_wording.rb
@@ -38,7 +38,7 @@ module RuboCop
         end
 
         def autocorrect(range)
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             corrector.replace(range, corrected_message(range))
           end
         end

--- a/rubocop-rspec.gemspec
+++ b/rubocop-rspec.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.test_files = spec.files.grep(/^spec\//)
   spec.extra_rdoc_files = ['MIT-LICENSE.md', 'README.md']
 
-  spec.add_development_dependency('rubocop', '~> 0.24')
+  spec.add_development_dependency('rubocop', '~> 0.31')
   spec.add_development_dependency('rake', '~> 10.1')
   spec.add_development_dependency('rspec', '~> 3.0')
   spec.add_development_dependency('simplecov', '~> 0.8')

--- a/rubocop-rspec.gemspec
+++ b/rubocop-rspec.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
     'Gemfile',
     'Rakefile'
   ]
-  spec.test_files = spec.files.grep(/^spec\//)
+  spec.test_files = spec.files.grep(%r{^spec/})
   spec.extra_rdoc_files = ['MIT-LICENSE.md', 'README.md']
 
   spec.add_development_dependency('rubocop', '~> 0.31')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,8 +2,11 @@
 
 require 'rubocop'
 
-rubocop_gem_path = Gem::Specification.find_by_name('rubocop').gem_dir
-Dir["#{rubocop_gem_path}/spec/support/**/*.rb"].each { |f| require f }
+rubocop_path = File.join(File.dirname(__FILE__), '../vendor/rubocop')
+unless File.directory?(rubocop_path)
+  fail "Can't run specs without a local RuboCop checkout. Look in the README."
+end
+Dir["#{rubocop_path}/spec/support/**/*.rb"].each { |f| require f }
 
 RSpec.configure do |config|
   config.order = :random


### PR DESCRIPTION
Running the specs depends on being able to load RuboCop's spec helpers. Since the RuboCop gem no longer (as of [v0.30.0](https://github.com/bbatsov/rubocop/commit/5e8199ed0b3f6cf50cb63a59311278eebc8683fa)) contains the spec files, we have to vendorize RuboCop.

We can make a git submodule, or we can make a git clone, and I have only heard bad things about using submodules in git. And making a shallow clone is relatively fast.

Potential issues:

 - The vendorized RuboCop and the RuboCop gem dependency may be out of sync, in a number of ways:
   - Travis will always checkout the master branch of RuboCop.
   - A locally vendorized RuboCop becomes outdated without warning.
