### PR TITLE
Ignore routing specs for DescribeClass cop

### DIFF
--- a/lib/rubocop/cop/rspec/describe_class.rb
+++ b/lib/rubocop/cop/rspec/describe_class.rb
@@ -22,6 +22,7 @@ module RuboCop
 
         REQUEST_PAIR = s(:pair, s(:sym, :type), s(:sym, :request))
         FEATURE_PAIR = s(:pair, s(:sym, :type), s(:sym, :feature))
+        ROUTING_PAIR = s(:pair, s(:sym, :type), s(:sym, :routing))
 
         MESSAGE = 'The first argument to describe should be the class or ' \
                   'module being tested.'
@@ -32,7 +33,7 @@ module RuboCop
           return if args[1..-1].any? do |arg|
             next unless arg.hash_type?
             arg.children.any? do |n|
-              [REQUEST_PAIR, FEATURE_PAIR].include?(n)
+              [REQUEST_PAIR, FEATURE_PAIR, ROUTING_PAIR].include?(n)
             end
           end
 

--- a/spec/rubocop/cop/rspec/describe_class_spec.rb
+++ b/spec/rubocop/cop/rspec/describe_class_spec.rb
@@ -36,6 +36,11 @@ describe RuboCop::Cop::RSpec::DescribeClass do
     inspect_source(cop, "describe 'my new feature', type: :feature do; end")
     expect(cop.offenses).to be_empty
   end
+  
+  it 'ignores routing specs' do
+    inspect_source(cop, "describe 'my new feature', type: :routing do; end")
+    expect(cop.offenses).to be_empty
+  end
 
   it 'ignores feature specs - also with complex options' do
     inspect_source(cop, ["describe 'my new feature',",


### PR DESCRIPTION
In the same vein as the request and feature specs: https://www.relishapp.com/rspec/rspec-rails/docs/routing-specs

I can squash if you would be interested in merging this :thumbsup: