### PR TITLE
'RSpec' class should translate to 'rspec' file path instead of 'r_spec'

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
 --require spec_helper
+--color

--- a/lib/rubocop/cop/rspec/file_path.rb
+++ b/lib/rubocop/cop/rspec/file_path.rb
@@ -19,6 +19,9 @@ module RuboCop
 
         MESSAGE = 'Spec path should end with `%s`'
         METHOD_STRING_MATCHER = /^[\#\.].+/
+        EXCEPTIONS = {
+          'RSpec' => 'rspec'
+        }
 
         def on_top_level_describe(node, args)
           return unless single_top_level_describe?
@@ -53,11 +56,19 @@ module RuboCop
         end
 
         def camel_to_underscore(string)
-          string.dup.tap do |result|
+          filter_exceptions(string).dup.tap do |result|
             result.gsub!(/([^A-Z])([A-Z]+)/,          '\\1_\\2')
             result.gsub!(/([A-Z])([A-Z][^A-Z]+)/, '\\1_\\2')
             result.downcase!
           end
+        end
+
+        def filter_exceptions(string)
+          output = string.dup
+          EXCEPTIONS.each do |from, to|
+            output.gsub!(from, to)
+          end
+          output
         end
 
         def regexp_from_glob(glob)

--- a/spec/rubocop/cop/rspec/file_path_spec.rb
+++ b/spec/rubocop/cop/rspec/file_path_spec.rb
@@ -73,6 +73,13 @@ describe RuboCop::Cop::RSpec::FilePath, :config do
     expect(cop.offenses).to be_empty
   end
 
+  it 'handles exception for class names including RSpec' do
+    inspect_source(cop,
+                   'describe RSpecHelper do; end',
+                   'rspec_helper_spec.rb')
+    expect(cop.offenses).to be_empty
+  end
+
   it 'handles ACRONYMClassNames' do
     inspect_source(cop,
                    'describe ABCOne::Two do; end',


### PR DESCRIPTION
'RSpec' is typically translated into 'rspec' instead of 'r_spec' in the underscore notation. `RSpec::FilePath` cop should also conform to this.