### PR TITLE
Fix Travis test/builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
+cache: bundler
 language: ruby
 rvm:
   - 1.9.3
   - 2.0.0
   - 2.1
+  - 2.2
+  - 2.3
   - ruby-head
   - jruby-19mode
   - rbx-2
@@ -10,6 +13,7 @@ matrix:
   allow_failures:
     - rvm: ruby-head
     - rvm: rbx-2
+  fast_finish: true
 before_install:
  - gem update --remote bundler
  - git clone --depth 1 git://github.com/bbatsov/rubocop.git vendor/rubocop

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ rvm:
   - 2.0.0
   - 2.1
   - 2.2
-  - 2.3
+  - 2.3.0
   - ruby-head
   - jruby-19mode
   - rbx-2
@@ -19,3 +19,6 @@ before_install:
  - git clone --depth 1 git://github.com/bbatsov/rubocop.git vendor/rubocop
 script:
   - bundle exec rake
+addons:
+  code_climate:
+    repo_token: XXXX

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :test do
-  gem 'coveralls', require: false
+  gem 'codeclimate-test-reporter', require: false
 end
 
 local_gemfile = 'Gemfile.local'

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Gem Version](https://badge.fury.io/rb/rubocop-rspec.png)](https://rubygems.org/gems/rubocop-rspec)
 [![Dependency Status](https://gemnasium.com/nevir/rubocop-rspec.png)](https://gemnasium.com/nevir/rubocop-rspec)
 [![Build Status](https://secure.travis-ci.org/nevir/rubocop-rspec.png?branch=master)](http://travis-ci.org/nevir/rubocop-rspec)
-[![Coverage Status](https://coveralls.io/repos/nevir/rubocop-rspec/badge.png?branch=master)](https://coveralls.io/r/nevir/rubocop-rspec)
+[![Test Coverage](https://codeclimate.com/github/nevir/rubocop-rspec/badges/coverage.png)](https://codeclimate.com/github/nevir/rubocop-rspec/coverage)
 [![Code Climate](https://codeclimate.com/github/nevir/rubocop-rspec.png)](https://codeclimate.com/github/nevir/rubocop-rspec)
 
 RSpec-specific analysis for your projects, as an extension to

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,11 @@
 
 require 'rubocop'
 
+if ENV['TRAVIS']
+  require 'codeclimate-test-reporter'
+  CodeClimate::TestReporter.start
+end
+
 rubocop_path = File.join(File.dirname(__FILE__), '../vendor/rubocop')
 unless File.directory?(rubocop_path)
   fail "Can't run specs without a local RuboCop checkout. Look in the README."


### PR DESCRIPTION
#### Fix Travis test
Test against Ruby 2.2 and 2.3
Also speed up tests by caching the bundler directory, and prevent test
suites which are allowed to fail from delaying the reporting of success.

This relies on #60 and #61, which introduce fixes for Ruby >2.1 and
having the correctly versioned Rubocop source available.

#### Switch from Coveralls to CodeClimate
CodeClimate is already used for code analysis so we can use it for test
coverage quite easily.


## NOTE: 
@nevir You need to replace the `XXXX` in `.travis.yml` with the actual CodeClimate repo token, which you can get by following the instructions [here](https://docs.codeclimate.com/docs/setting-up-test-coverage).