### PR TITLE
Clean-Up NotToNot and Add Autocorrect Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master (unreleased)
 
 * Add cop to check for focused specs. ([@renanborgescampos][], [@jaredmoody][])
+* Clean-up `RSpec::NotToNot` to use same configuration semantics as other Rubocop cops, add autocorrect support for `RSpec::NotToNot`. ([@baberthal][])
 
 ## 1.4.1 (03/04/2016)
 
@@ -87,3 +88,4 @@
 [@mlarraz]: https://github.com/mlarraz
 [@renanborgescampos]: https://github.com/renanborgescampos
 [@jaredmoody]: https://github.com/jaredmoody
+[@baberthal]: https://github.com/baberthal

--- a/config/default.yml
+++ b/config/default.yml
@@ -45,8 +45,11 @@ RSpec/VerifiedDoubles:
 
 RSpec/NotToNot:
   Description: 'Enforces the usage of the same method on all negative message expectations.'
+  EnforcedStyle: not_to
+  SupportedStyles:
+    - not_to
+    - to_not
   Enabled: true
-  AcceptedMethod: 'not_to'
 
 RSpec/Focus:
   Description: 'Checks if there are focused specs.'

--- a/spec/rubocop/cop/rspec/not_to_not_spec.rb
+++ b/spec/rubocop/cop/rspec/not_to_not_spec.rb
@@ -3,13 +3,13 @@
 describe RuboCop::Cop::RSpec::NotToNot, :config do
   subject(:cop) { described_class.new(config) }
 
-  context 'when AcceptedMethod is `not_to`' do
-    let(:cop_config) { { 'AcceptedMethod' => 'not_to' } }
+  context 'when EnforcedStyle is `not_to`' do
+    let(:cop_config) { { 'EnforcedStyle' => 'not_to' } }
 
     it 'detects the `to_not` offense' do
       inspect_source(subject, 'it { expect(false).to_not be_true }')
 
-      expect(subject.messages).to eq(['Use `not_to` instead of `to_not`'])
+      expect(subject.messages).to eq(['Prefer `not_to` over `to_not`'])
       expect(subject.highlights).to eq(['expect(false).to_not be_true'])
       expect(subject.offenses.map(&:line).sort).to eq([1])
     end
@@ -19,15 +19,20 @@ describe RuboCop::Cop::RSpec::NotToNot, :config do
 
       expect(subject.messages).to be_empty
     end
+
+    it 'auto-corrects `to_not` to `not_to`' do
+      corrected = autocorrect_source(cop, ['it { expect(0).to_not equal 1 }'])
+      expect(corrected).to eq 'it { expect(0).not_to equal 1 }'
+    end
   end
 
   context 'when AcceptedMethod is `to_not`' do
-    let(:cop_config) { { 'AcceptedMethod' => 'to_not' } }
+    let(:cop_config) { { 'EnforcedStyle' => 'to_not' } }
 
     it 'detects the `not_to` offense' do
       inspect_source(subject, 'it { expect(false).not_to be_true }')
 
-      expect(subject.messages).to eq(['Use `to_not` instead of `not_to`'])
+      expect(subject.messages).to eq(['Prefer `to_not` over `not_to`'])
       expect(subject.highlights).to eq(['expect(false).not_to be_true'])
       expect(subject.offenses.map(&:line).sort).to eq([1])
     end
@@ -36,6 +41,11 @@ describe RuboCop::Cop::RSpec::NotToNot, :config do
       inspect_source(subject, 'it { expect(false).to_not be_true }')
 
       expect(subject.messages).to be_empty
+    end
+
+    it 'auto-corrects `not_to` to `to_not`' do
+      corrected = autocorrect_source(cop, ['it { expect(0).not_to equal 1 }'])
+      expect(corrected).to eq 'it { expect(0).to_not equal 1 }'
     end
   end
 end


### PR DESCRIPTION
Clean-up the implementation and interface for NotToNot to use the
RuboCop mixin ConfigurableEnforcedStyle, allowing for the same
configuration semantics as most other RuboCop Cops.

Additionally, add autocorrect support for the NotToNot cop.

If you'd like, I can keep going on the rest of the Cops.