### PR TITLE
Fix the loading of the default config file

### DIFF
--- a/lib/rubocop/rspec/inject.rb
+++ b/lib/rubocop/rspec/inject.rb
@@ -13,10 +13,11 @@ module RuboCop
 
       def self.defaults!
         hash = YAML.load_file(DEFAULT_FILE)
-        puts "configuration from #{DEFAULT_FILE}" if ConfigLoader.debug?
-        config = ConfigLoader.merge_with_default(hash, DEFAULT_FILE)
+        config = Config.new(hash, DEFAULT_FILE)
+        puts "Merging rubocop-rspec default configuration from #{DEFAULT_FILE}" if ConfigLoader.debug?
+        config = ConfigLoader.merge_with_default(config, DEFAULT_FILE)
 
-        ConfigLoader.instance_variable_set(:@default_configuration, config)
+        ConfigLoader.default_configuration = config
       end
     end
   end


### PR DESCRIPTION
A recent change in RuboCop made it so that the argument passed to
`ConfigLoader.merge_with_default` has to be of type RuboCop::Config
instead of a plain Hash.

fixes: #78