### PR TITLE
Skip `FilePath` cop for Rails routing specs

### DIFF
--- a/lib/rubocop/cop/rspec/file_path.rb
+++ b/lib/rubocop/cop/rspec/file_path.rb
@@ -20,8 +20,11 @@ module RuboCop
 
         MESSAGE = 'Spec path should end with `%s`'.freeze
         METHOD_STRING_MATCHER = /^[\#\.].+/
+        ROUTING_PAIR = s(:pair, s(:sym, :type), s(:sym, :routing))
 
         def on_top_level_describe(node, args)
+          return if routing_spec?(args)
+
           return unless single_top_level_describe?
           object = args.first.const_name
           return unless object
@@ -33,6 +36,13 @@ module RuboCop
         end
 
         private
+
+        def routing_spec?(args)
+          args[1..-1].any? do |arg|
+            next unless arg.hash_type?
+            arg.children.include?(ROUTING_PAIR)
+          end
+        end
 
         def matcher(object, method)
           path = File.join(parts(object))

--- a/spec/rubocop/cop/rspec/file_path_spec.rb
+++ b/spec/rubocop/cop/rspec/file_path_spec.rb
@@ -156,4 +156,11 @@ describe RuboCop::Cop::RSpec::FilePath, :config do
                    'foofoo/some/class/bar_spec.rb')
     expect(cop.offenses).to be_empty
   end
+
+  it 'ignores routing specs' do
+    inspect_source(cop,
+                   'describe MyController, type: :routing do; end',
+                   'foofoo/some/class/bar_spec.rb')
+    expect(cop.offenses).to be_empty
+  end
 end


### PR DESCRIPTION
The [template](https://github.com/rspec/rspec-rails/blob/master/lib/generators/rspec/scaffold/templates/routing_spec.rb#L4) rspec-rails uses to create a routing spec violates the rule enforced by the `FilePath` cop. It is expected that `routing/user_routing_spec.rb` should use `describe UserController, type: :routing` as the spec's class declaration.

Closes #13

@geniou @acurley 