### PR TITLE
Fix runtime dependency to rubocop

### DIFF
--- a/rubocop-rspec.gemspec
+++ b/rubocop-rspec.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.test_files = spec.files.grep(%r{^spec/})
   spec.extra_rdoc_files = ['MIT-LICENSE.md', 'README.md']
 
-  spec.add_runtime_dependency 'rubocop', '0.39.0'
+  spec.add_runtime_dependency 'rubocop', '>= 0.39.0'
 
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '>= 3.4'


### PR DESCRIPTION
In order to allow rubocop-rspec to continue to work with newer rubocop releases