### PR TITLE
Fix GitHub profile link for @andyw8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,7 +84,7 @@
 
 <!-- Contributors -->
 
-[@andyw8]: https://github.com/andyw8i
+[@andyw8]: https://github.com/andyw8
 [@bquorning]: https://github.com/bquorning
 [@deivid-rodriguez]: https://github.com/deivid-rodriguez
 [@geniou]: https://github.com/geniou


### PR DESCRIPTION
Looks like there was an accidental change in e196428551936e353b83be3bb85c1825124b7b9a