### PR TITLE
Fix `unrecognized parameter RSpec/VerifiedDoubles:IgnoreSymbolicNames` warning

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -42,6 +42,7 @@ RSpec/FilePath:
 RSpec/VerifiedDoubles:
   Description: 'Prefer using verifying doubles over normal doubles.'
   Enabled: true
+  IgnoreSymbolicNames: false
 
 RSpec/NotToNot:
   Description: 'Enforces the usage of the same method on all negative message expectations.'


### PR DESCRIPTION
`config/default.yml` does not include `IgnoreSymbolicNames` for the `VerifiedDoubles` cop. This results in a warning when specifying `IgnoreSymbolicNames: true`. This PR adds `IgnoreSymbolicNames` to `default.yml` and squashes this warning.

It doesn't appear that the defaults are tested via RSpec, either in `rubocop-rspec` or `rubocop`. Tested manually by adding:
```
RSpec/VerifiedDoubles:
  IgnoreSymbolicNames: true
```
to .rubocop.yml. Without this addition, running `rubocop` generates a warning:
```
Warning: unrecognized parameter RSpec/VerifiedDoubles:IgnoreSymbolicNames found in .../.rubocop.yml
```
With this addition the warning is silenced.
