### PR TITLE
Add DefaultHookArgument cop

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -2,6 +2,10 @@ RSpec/AnyInstance:
   Description: 'Check that instances are not being stubbed globally'
   Enabled: true
 
+RSpec/DefaultHookArgument:
+  Description: 'Omit the default `:each` argument for RSpec hooks.'
+  Enabled: true
+
 RSpec/DescribeClass:
   Description: 'Check that the first argument to the top level describe is the tested class or module.'
   Enabled: true
@@ -22,7 +26,6 @@ RSpec/ExampleWording:
     have: has
     not: does not
   IgnoredWords: []
-
 
 RSpec/MultipleDescribes:
   Description: 'Checks for multiple top level describes.'

--- a/lib/rubocop-rspec.rb
+++ b/lib/rubocop-rspec.rb
@@ -10,6 +10,7 @@ RuboCop::RSpec::Inject.defaults!
 
 # cops
 require 'rubocop/cop/rspec/any_instance'
+require 'rubocop/cop/rspec/default_hook_argument'
 require 'rubocop/cop/rspec/describe_class'
 require 'rubocop/cop/rspec/describe_method'
 require 'rubocop/cop/rspec/described_class'

--- a/lib/rubocop/cop/rspec/default_hook_argument.rb
+++ b/lib/rubocop/cop/rspec/default_hook_argument.rb
@@ -1,0 +1,38 @@
+# encoding: utf-8
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module RSpec
+      # Omit the default :each argument for RSpec hooks.
+      #
+      # @example
+      #   # bad
+      #   before(:each) do
+      #     ...
+      #   end
+      #
+      #   # good
+      #   before do
+      #     ...
+      #   end
+      class DefaultHookArgument < RuboCop::Cop::Cop
+        MSG = 'Omit the default `:%s` argument for RSpec hooks.'.freeze
+
+        HOOK_METHODS = [:after, :around, :before].freeze
+        DEFAULT_ARGS = [:each, :example].freeze
+
+        def on_send(node)
+          return unless HOOK_METHODS.include?(node.method_name)
+
+          arg_node = node.method_args.first
+          arg, = *arg_node
+
+          return unless DEFAULT_ARGS.include?(arg)
+
+          add_offense(arg_node, :expression, format(MSG, arg))
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/rspec/default_hook_argument_spec.rb
+++ b/spec/rubocop/cop/rspec/default_hook_argument_spec.rb
@@ -1,0 +1,49 @@
+# encoding: utf-8
+
+describe RuboCop::Cop::RSpec::DefaultHookArgument do
+  subject(:cop) { described_class.new }
+
+  it 'checks `before` hooks' do
+    inspect_source(cop, 'before(:each) { true }')
+
+    expect(cop.offenses.size).to eq(1)
+  end
+
+  it 'checks `after` hooks' do
+    inspect_source(cop, 'after(:each) { true }')
+
+    expect(cop.offenses.size).to eq(1)
+  end
+
+  it 'checks `around` hooks' do
+    inspect_source(cop, 'around(:each) { |ex| true }')
+
+    expect(cop.offenses.size).to eq(1)
+  end
+
+  it 'detects `:each`' do
+    inspect_source(cop, 'before(:each) { true }')
+
+    expect(cop.offenses.map(&:line).sort).to eq([1])
+    expect(cop.highlights).to eq([':each'])
+  end
+
+  it 'detects `:example`' do
+    inspect_source(cop, 'before(:example) { true }')
+
+    expect(cop.offenses.map(&:line).sort).to eq([1])
+    expect(cop.highlights).to eq([':example'])
+  end
+
+  it 'ignores `:context`' do
+    inspect_source(cop, 'before(:context) { true }')
+
+    expect(cop.offenses).to be_empty
+  end
+
+  it 'ignores `:suite`' do
+    inspect_source(cop, 'before(:suite) { true }')
+
+    expect(cop.offenses).to be_empty
+  end
+end


### PR DESCRIPTION
This cop will add offenses when an RSpec hook method (`before`, `after`,
`around`) receives the default `:each` or `:example` argument.