### PR TITLE
Remove the requirement for a rubocop submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "vendor/rubocop"]
-    path = vendor/rubocop
-    url = https://github.com/bbatsov/rubocop.git

--- a/README.md
+++ b/README.md
@@ -80,14 +80,6 @@ RSpec/FilePath:
 4. Push to the branch (`git push origin my-new-feature`)
 5. Create new Pull Request
 
-For running the spec files, this project depends on RuboCop's spec helpers.
-This means that in order to run the specs locally, you need a (shallow) clone
-of the RuboCop repository:
-
-```bash
-git submodule update --init vendor/rubocop
-```
-
 ## License
 
 `rubocop-rspec` is MIT licensed. [See the accompanying file](MIT-LICENSE.md) for

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,13 +2,7 @@
 
 require 'rubocop'
 
-rubocop_path = File.join(File.dirname(__FILE__), '../vendor/rubocop')
-
-unless File.directory?(rubocop_path)
-  raise "Can't run specs without a local RuboCop checkout. Look in the README."
-end
-
-Dir["#{rubocop_path}/spec/support/**/*.rb"].each { |f| require f }
+require 'rubocop/rspec/support'
 
 if ENV['CI']
   require 'codeclimate-test-reporter'


### PR DESCRIPTION
The latest RuboCop version (v0.41.1) exposes files to support testing with RSpec.