### PR TITLE
Use spec helpers exposed by RuboCop

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "vendor/rubocop"]
-    path = vendor/rubocop
-    url = https://github.com/bbatsov/rubocop.git

--- a/README.md
+++ b/README.md
@@ -80,14 +80,6 @@ RSpec/FilePath:
 4. Push to the branch (`git push origin my-new-feature`)
 5. Create new Pull Request
 
-For running the spec files, this project depends on RuboCop's spec helpers.
-This means that in order to run the specs locally, you need a (shallow) clone
-of the RuboCop repository:
-
-```bash
-git submodule update --init vendor/rubocop
-```
-
 ## License
 
 `rubocop-rspec` is MIT licensed. [See the accompanying file](MIT-LICENSE.md) for

--- a/rubocop-rspec.gemspec
+++ b/rubocop-rspec.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.test_files = spec.files.grep(%r{^spec/})
   spec.extra_rdoc_files = ['MIT-LICENSE.md', 'README.md']
 
-  spec.add_runtime_dependency 'rubocop', '>= 0.40.0'
+  spec.add_runtime_dependency 'rubocop', '>= 0.41.1'
 
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '>= 3.4'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,14 +1,6 @@
 # encoding: utf-8
 
-require 'rubocop'
-
-rubocop_path = File.join(File.dirname(__FILE__), '../vendor/rubocop')
-
-unless File.directory?(rubocop_path)
-  raise "Can't run specs without a local RuboCop checkout. Look in the README."
-end
-
-Dir["#{rubocop_path}/spec/support/**/*.rb"].each { |f| require f }
+require 'rubocop/rspec/support'
 
 if ENV['CI']
   require 'codeclimate-test-reporter'


### PR DESCRIPTION
In RuboCop v0.41.0, spec helpers are released as part of the gem. This means that installing all of the RuboCop source as a git submodule, and jumping through hoops to require the correct files, is no longer needed.

See https://github.com/bbatsov/rubocop/pull/3179, https://github.com/nevir/rubocop-rspec/pull/39 and https://github.com/nevir/rubocop-rspec/pull/61

cc/ @geniou, @nijikon, @jawshooah 

