### PR TITLE
Remove jruby and rbx from build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,19 +6,10 @@ rvm:
   - 2.2.5
   - 2.3.1
   - ruby-head
-  - jruby-9.1.0.0
-  - rbx-3
-
-env:
-  # this doesn't do anything for MRI or RBX, but it doesn't hurt them either
-  # for JRuby, it enables us to get more accurate coverage data
-  - JRUBY_OPTS="--debug"
 
 matrix:
   allow_failures:
-    - rvm: jruby-9.1.0.0
     - rvm: ruby-head
-    - rvm: rbx-3
   fast_finish: true
 
 addons:


### PR DESCRIPTION
See 4317e8f for reasoning. Having jruby in the build still
slows things down