### PR TITLE
Fix regression in DescribeClass

### DIFF
--- a/lib/rubocop/cop/rspec/describe_class.rb
+++ b/lib/rubocop/cop/rspec/describe_class.rb
@@ -24,11 +24,11 @@ module RuboCop
               'the class or module being tested.'.freeze
 
         def_node_matcher :valid_describe?, <<-PATTERN
-        {(send nil :describe const ...) (send nil :describe)}
+        {(send {(const nil :RSpec) nil} :describe const ...) (send nil :describe)}
         PATTERN
 
         def_node_matcher :describe_with_metadata, <<-PATTERN
-        (send nil :describe
+        (send {(const nil :RSpec) nil} :describe
           !const
           ...
           (hash $...))

--- a/spec/rubocop/cop/rspec/describe_class_spec.rb
+++ b/spec/rubocop/cop/rspec/describe_class_spec.rb
@@ -9,6 +9,11 @@ describe RuboCop::Cop::RSpec::DescribeClass do
                                 'the class or module being tested.'])
   end
 
+  it 'supports RSpec.describe' do
+    inspect_source(cop, 'RSpec.describe Foo do; end')
+    expect(cop.offenses).to be_empty
+  end
+
   it 'checks describe statements after a require' do
     inspect_source(
       cop,
@@ -47,6 +52,15 @@ describe RuboCop::Cop::RSpec::DescribeClass do
 
   it 'ignores feature specs' do
     inspect_source(cop, "describe 'my new feature', type: :feature do; end")
+    expect(cop.offenses).to be_empty
+  end
+
+  it 'ignores feature specs when RSpec.describe is used' do
+    inspect_source(
+      cop,
+      "RSpec.describe 'my new feature', type: :feature do; end"
+    )
+
     expect(cop.offenses).to be_empty
   end
 


### PR DESCRIPTION
My update to use `def_node_matcher` did not account for `RSpec.describe`