### PR TITLE
Add expect_violation spec support

### DIFF
--- a/rubocop-rspec.gemspec
+++ b/rubocop-rspec.gemspec
@@ -35,4 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '>= 3.4'
   spec.add_development_dependency 'simplecov'
+  spec.add_development_dependency 'anima'
+  spec.add_development_dependency 'concord'
+  spec.add_development_dependency 'adamantium'
 end

--- a/spec/expect_violation/expectation_spec.rb
+++ b/spec/expect_violation/expectation_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+RSpec.describe ExpectViolation::Expectation do
+  subject(:expectation) { described_class.new(string) }
+
+  context 'when given a single assertion on class end' do
+    let(:string) do
+      <<-SRC
+      class Foo
+      end
+      ^^^ The end of `Foo` should be annotated.
+      SRC
+    end
+
+    let(:assertion) { expectation.assertions.first }
+
+    it 'has one assertion' do
+      expect(expectation.assertions.size).to be(1)
+    end
+
+    it 'has an assertion on line 2' do
+      expect(assertion.line_number).to be(2)
+    end
+
+    it 'has an assertion on column range 1-3' do
+      expect(assertion.column_range).to eql(6...9)
+    end
+
+    it 'has an assertion with correct violation message' do
+      expect(assertion.message).to eql('The end of `Foo` should be annotated.')
+    end
+
+    it 'recreates source' do
+      expect(expectation.source).to eql(<<-RUBY)
+      class Foo
+      end
+      RUBY
+    end
+  end
+
+  context 'when given many assertions on two lines' do
+    let(:string) do
+      <<-SRC
+      foo bar
+          ^ Charlie
+         ^^ Charlie
+          ^^ Bronco
+          ^^ Alpha
+      baz
+      ^ Delta
+      SRC
+    end
+
+    let(:assertions) { expectation.assertions.sort }
+
+    it 'has two assertions' do
+      expect(expectation.assertions.size).to be(5)
+    end
+
+    it 'has assertions on lines 1 and 2' do
+      expect(assertions.map(&:line_number)).to eql(
+        [1, 1, 1, 1, 2]
+      )
+    end
+
+    it 'has assertions on column range 1-3' do
+      expect(assertions.map(&:column_range)).to eql(
+        [9...11, 10...11, 10...12, 10...12, 6...7]
+      )
+    end
+
+    it 'has an assertion with correct violation message' do
+      expect(assertions.map(&:message)).to eql(
+        %w(Charlie Charlie Alpha Bronco Delta)
+      )
+    end
+
+    it 'recreates source' do
+      expect(expectation.source).to eql(<<-RUBY)
+      foo bar
+      baz
+      RUBY
+    end
+  end
+end

--- a/spec/rubocop/cop/rspec/any_instance_spec.rb
+++ b/spec/rubocop/cop/rspec/any_instance_spec.rb
@@ -2,47 +2,29 @@ describe RuboCop::Cop::RSpec::AnyInstance do
   subject(:cop) { described_class.new }
 
   it 'finds `allow_any_instance_of` instead of an instance double' do
-    inspect_source(
-      cop,
-      [
-        'before do',
-        '  allow_any_instance_of(Object).to receive(:foo)',
-        'end'
-      ]
-    )
-    expect(cop.messages)
-      .to eq(['Avoid stubbing using `allow_any_instance_of`'])
-    expect(cop.highlights).to eq(['allow_any_instance_of(Object)'])
-    expect(cop.offenses.map(&:line).sort).to eq([2])
+    expect_violation(<<-RUBY)
+      before do
+        allow_any_instance_of(Object).to receive(:foo)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid stubbing using `allow_any_instance_of`
+      end
+    RUBY
   end
 
   it 'finds `expect_any_instance_of` instead of an instance double' do
-    inspect_source(
-      cop,
-      [
-        'before do',
-        '  expect_any_instance_of(Object).to receive(:foo)',
-        'end'
-      ]
-    )
-    expect(cop.messages)
-      .to eq(['Avoid stubbing using `expect_any_instance_of`'])
-    expect(cop.highlights).to eq(['expect_any_instance_of(Object)'])
-    expect(cop.offenses.map(&:line).sort).to eq([2])
+    expect_violation(<<-RUBY)
+      before do
+        expect_any_instance_of(Object).to receive(:foo)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid stubbing using `expect_any_instance_of`
+      end
+    RUBY
   end
 
   it 'finds old `any_instance` syntax instead of an instance double' do
-    inspect_source(
-      cop,
-      [
-        'before do',
-        '  Object.any_instance.should_receive(:foo)',
-        'end'
-      ]
-    )
-    expect(cop.messages)
-      .to eq(['Avoid stubbing using `any_instance`'])
-    expect(cop.highlights).to eq(['Object.any_instance'])
-    expect(cop.offenses.map(&:line).sort).to eq([2])
+    expect_violation(<<-RUBY)
+      before do
+        Object.any_instance.should_receive(:foo)
+        ^^^^^^^^^^^^^^^^^^^ Avoid stubbing using `any_instance`
+      end
+    RUBY
   end
 end

--- a/spec/rubocop/cop/rspec/describe_class_spec.rb
+++ b/spec/rubocop/cop/rspec/describe_class_spec.rb
@@ -10,7 +10,7 @@ describe RuboCop::Cop::RSpec::DescribeClass do
   end
 
   it 'supports RSpec.describe' do
-    expect_violation(<<-RUBY)
+    expect_no_violations(<<-RUBY)
       RSpec.describe Foo do
       end
     RUBY
@@ -34,7 +34,7 @@ describe RuboCop::Cop::RSpec::DescribeClass do
   end
 
   it 'ignores nested describe statements' do
-    expect_violation(<<-RUBY)
+    expect_no_violations(<<-RUBY)
       describe Some::Class do
         describe "bad describe" do
         end
@@ -43,21 +43,21 @@ describe RuboCop::Cop::RSpec::DescribeClass do
   end
 
   it 'ignores request specs' do
-    expect_violation(<<-RUBY)
+    expect_no_violations(<<-RUBY)
       describe 'my new feature', type: :request do
       end
     RUBY
   end
 
   it 'ignores feature specs' do
-    expect_violation(<<-RUBY)
+    expect_no_violations(<<-RUBY)
       describe 'my new feature', type: :feature do
       end
     RUBY
   end
 
   it 'ignores feature specs when RSpec.describe is used' do
-    expect_violation(<<-RUBY)
+    expect_no_violations(<<-RUBY)
       RSpec.describe 'my new feature', type: :feature do
       end
     RUBY
@@ -80,34 +80,34 @@ describe RuboCop::Cop::RSpec::DescribeClass do
   end
 
   it 'ignores feature specs - also with complex options' do
-    expect_violation(<<-RUBY)
+    expect_no_violations(<<-RUBY)
       describe 'my new feature', :test, :type => :feature, :foo => :bar do
       end
     RUBY
   end
 
   it 'ignores an empty describe' do
-    expect_violation(<<-RUBY)
+    expect_no_violations(<<-RUBY)
       describe do
       end
     RUBY
   end
 
   it 'ignores routing specs' do
-    expect_violation(<<-RUBY)
+    expect_no_violations(<<-RUBY)
       describe 'my new route', type: :routing do
       end
     RUBY
   end
 
   it 'ignores view specs' do
-    expect_violation(<<-RUBY)
+    expect_no_violations(<<-RUBY)
       describe 'widgets/index', type: :view do
       end
     RUBY
   end
 
   it "doesn't blow up on single-line describes" do
-    expect_violation('describe Some::Class')
+    expect_no_violations('describe Some::Class')
   end
 end

--- a/spec/rubocop/cop/rspec/describe_class_spec.rb
+++ b/spec/rubocop/cop/rspec/describe_class_spec.rb
@@ -2,109 +2,112 @@ describe RuboCop::Cop::RSpec::DescribeClass do
   subject(:cop) { described_class.new }
 
   it 'checks first-line describe statements' do
-    inspect_source(cop, 'describe "bad describe" do; end')
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.offenses.map(&:line).sort).to eq([1])
-    expect(cop.messages).to eq(['The first argument to describe should be ' \
-                                'the class or module being tested.'])
+    expect_violation(<<-RUBY)
+      describe "bad describe" do
+               ^^^^^^^^^^^^^^ The first argument to describe should be the class or module being tested.
+      end
+    RUBY
   end
 
   it 'supports RSpec.describe' do
-    inspect_source(cop, 'RSpec.describe Foo do; end')
-    expect(cop.offenses).to be_empty
+    expect_violation(<<-RUBY)
+      RSpec.describe Foo do
+      end
+    RUBY
   end
 
   it 'checks describe statements after a require' do
-    inspect_source(
-      cop,
-      [
-        "require 'spec_helper'",
-        'describe "bad describe" do; end'
-      ]
-    )
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.offenses.map(&:line).sort).to eq([2])
-    expect(cop.messages).to eq(['The first argument to describe should be ' \
-                                'the class or module being tested.'])
+    expect_violation(<<-RUBY)
+      require 'spec_helper'
+      describe "bad describe" do
+               ^^^^^^^^^^^^^^ The first argument to describe should be the class or module being tested.
+      end
+    RUBY
   end
 
   it 'checks highlights the first argument of a describe' do
-    inspect_source(cop, 'describe "bad describe", "blah blah" do; end')
-    expect(cop.offenses.first.location.column_range).to eq(9...23)
+    expect_violation(<<-RUBY)
+      describe "bad describe", "blah blah" do
+               ^^^^^^^^^^^^^^ The first argument to describe should be the class or module being tested.
+      end
+    RUBY
   end
 
   it 'ignores nested describe statements' do
-    inspect_source(
-      cop,
-      [
-        'describe Some::Class do',
-        '  describe "bad describe" do; end',
-        'end'
-      ]
-    )
-    expect(cop.offenses).to be_empty
+    expect_violation(<<-RUBY)
+      describe Some::Class do
+        describe "bad describe" do
+        end
+      end
+    RUBY
   end
 
   it 'ignores request specs' do
-    inspect_source(cop, "describe 'my new feature', type: :request do; end")
-    expect(cop.offenses).to be_empty
+    expect_violation(<<-RUBY)
+      describe 'my new feature', type: :request do
+      end
+    RUBY
   end
 
   it 'ignores feature specs' do
-    inspect_source(cop, "describe 'my new feature', type: :feature do; end")
-    expect(cop.offenses).to be_empty
+    expect_violation(<<-RUBY)
+      describe 'my new feature', type: :feature do
+      end
+    RUBY
   end
 
   it 'ignores feature specs when RSpec.describe is used' do
-    inspect_source(
-      cop,
-      "RSpec.describe 'my new feature', type: :feature do; end"
-    )
-
-    expect(cop.offenses).to be_empty
+    expect_violation(<<-RUBY)
+      RSpec.describe 'my new feature', type: :feature do
+      end
+    RUBY
   end
 
   it 'flags specs with non :type metadata' do
-    inspect_source(cop, "describe 'my new feature', foo: :feature do; end")
-    expect(cop.messages).to eq(['The first argument to describe should be ' \
-                                'the class or module being tested.'])
+    expect_violation(<<-RUBY)
+      describe 'my new feature', foo: :feature do
+               ^^^^^^^^^^^^^^^^ The first argument to describe should be the class or module being tested.
+      end
+    RUBY
   end
 
   it 'flags normal metadata in describe' do
-    inspect_source(cop, "describe 'my new feature', blah, type: :wow do; end")
-    expect(cop.messages).to eq(['The first argument to describe should be ' \
-                                'the class or module being tested.'])
+    expect_violation(<<-RUBY)
+      describe 'my new feature', blah, type: :wow do
+               ^^^^^^^^^^^^^^^^ The first argument to describe should be the class or module being tested.
+      end
+    RUBY
   end
 
   it 'ignores feature specs - also with complex options' do
-    inspect_source(
-      cop,
-      [
-        "describe 'my new feature',",
-        '  :test, :type => :feature, :foo => :bar do;',
-        'end'
-      ]
-    )
-    expect(cop.offenses).to be_empty
+    expect_violation(<<-RUBY)
+      describe 'my new feature', :test, :type => :feature, :foo => :bar do
+      end
+    RUBY
   end
 
   it 'ignores an empty describe' do
-    inspect_source(cop, 'describe do; end')
-    expect(cop.offenses).to be_empty
+    expect_violation(<<-RUBY)
+      describe do
+      end
+    RUBY
   end
 
   it 'ignores routing specs' do
-    inspect_source(cop, "describe 'my new route', type: :routing do; end")
-    expect(cop.offenses).to be_empty
+    expect_violation(<<-RUBY)
+      describe 'my new route', type: :routing do
+      end
+    RUBY
   end
 
   it 'ignores view specs' do
-    inspect_source(cop, "describe 'widgets/index', type: :view do; end")
-    expect(cop.offenses).to be_empty
+    expect_violation(<<-RUBY)
+      describe 'widgets/index', type: :view do
+      end
+    RUBY
   end
 
   it "doesn't blow up on single-line describes" do
-    inspect_source(cop, 'describe Some::Class')
-    expect(cop.offenses).to be_empty
+    expect_violation('describe Some::Class')
   end
 end

--- a/spec/rubocop/cop/rspec/describe_method_spec.rb
+++ b/spec/rubocop/cop/rspec/describe_method_spec.rb
@@ -2,32 +2,31 @@ describe RuboCop::Cop::RSpec::DescribeMethod do
   subject(:cop) { described_class.new }
 
   it 'ignores describes with only a class' do
-    inspect_source(cop, 'describe Some::Class do; end')
-    expect(cop.offenses.empty?).to be(true)
+    expect_violation('describe Some::Class do; end')
   end
 
   it 'enforces non-method names' do
-    inspect_source(
-      cop,
-      "describe Some::Class, 'nope', '.incorrect_usage' do; end"
-    )
-
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.offenses.map(&:line).sort).to eq([1])
-    expect(cop.messages)
-      .to eq(['The second argument to describe should be the method being ' \
-              "tested. '#instance' or '.class'"])
+    expect_violation(<<-RUBY)
+      describe Some::Class, 'nope', '.incorrect_usage' do
+                            ^^^^^^ The second argument to describe should be the method being tested. '#instance' or '.class'
+      end
+    RUBY
   end
 
   it 'skips methods starting with a . or #' do
-    inspect_source(cop, ["describe Some::Class, '.asdf' do; end",
-                         "describe Some::Class, '#fdsa' do; end"])
-    expect(cop.offenses).to be_empty
+    expect_violation(<<-RUBY)
+      describe Some::Class, '.asdf' do
+      end
+
+      describe Some::Class, '#fdsa' do
+      end
+    RUBY
   end
 
   it 'skips specs not having a string second argument' do
-    inspect_source(cop, 'describe Some::Class, :config do; end')
-
-    expect(cop.offenses).to be_empty
+    expect_violation(<<-RUBY)
+      describe Some::Class, :config do
+      end
+    RUBY
   end
 end

--- a/spec/rubocop/cop/rspec/describe_method_spec.rb
+++ b/spec/rubocop/cop/rspec/describe_method_spec.rb
@@ -2,7 +2,7 @@ describe RuboCop::Cop::RSpec::DescribeMethod do
   subject(:cop) { described_class.new }
 
   it 'ignores describes with only a class' do
-    expect_violation('describe Some::Class do; end')
+    expect_no_violations('describe Some::Class do; end')
   end
 
   it 'enforces non-method names' do
@@ -14,7 +14,7 @@ describe RuboCop::Cop::RSpec::DescribeMethod do
   end
 
   it 'skips methods starting with a . or #' do
-    expect_violation(<<-RUBY)
+    expect_no_violations(<<-RUBY)
       describe Some::Class, '.asdf' do
       end
 
@@ -24,7 +24,7 @@ describe RuboCop::Cop::RSpec::DescribeMethod do
   end
 
   it 'skips specs not having a string second argument' do
-    expect_violation(<<-RUBY)
+    expect_no_violations(<<-RUBY)
       describe Some::Class, :config do
       end
     RUBY

--- a/spec/rubocop/cop/rspec/described_class_spec.rb
+++ b/spec/rubocop/cop/rspec/described_class_spec.rb
@@ -2,176 +2,126 @@ describe RuboCop::Cop::RSpec::DescribedClass do
   subject(:cop) { described_class.new }
 
   it 'checks for the use of the described class' do
-    inspect_source(
-      cop,
-      [
-        'describe MyClass do',
-        '  include MyClass',
-        '  subject { MyClass.do_something }',
-        '  before { MyClass.do_something }',
-        'end'
-      ]
-    )
-    expect(cop.offenses.size).to eq(3)
-    expect(cop.offenses.map(&:line).sort).to eq([2, 3, 4])
-    expect(cop.messages)
-      .to eq(['Use `described_class` instead of `MyClass`'] * 3)
-    expect(cop.highlights).to eq(['MyClass'] * 3)
+    expect_violation(<<-RUBY)
+      describe MyClass do
+        include MyClass
+                ^^^^^^^ Use `described_class` instead of `MyClass`
+
+        subject { MyClass.do_something }
+                  ^^^^^^^ Use `described_class` instead of `MyClass`
+
+        before { MyClass.do_something }
+                 ^^^^^^^ Use `described_class` instead of `MyClass`
+      end
+    RUBY
   end
 
   it 'ignores described class as string' do
-    inspect_source(
-      cop,
-      [
-        'describe MyClass do',
-        '  subject { "MyClass" }',
-        'end'
-      ]
-    )
-    expect(cop.offenses).to be_empty
+    expect_violation(<<-RUBY)
+      describe MyClass do
+        subject { "MyClass" }
+      end
+    RUBY
   end
 
   it 'ignores describe that do not referece to a class' do
-    inspect_source(
-      cop,
-      [
-        'describe "MyClass" do',
-        '  subject { "MyClass" }',
-        'end'
-      ]
-    )
-    expect(cop.offenses).to be_empty
+    expect_violation(<<-RUBY)
+      describe "MyClass" do
+        subject { "MyClass" }
+      end
+    RUBY
   end
 
   it 'ignores class if the scope is changing' do
-    inspect_source(
-      cop,
-      [
-        'describe MyClass do',
-        '  def method',
-        '    include MyClass',
-        '  end',
-        '  class OtherClass',
-        '    include MyClass',
-        '  end',
-        '  module MyModle',
-        '    include MyClass',
-        '  end',
-        'end'
-      ]
-    )
-    expect(cop.offenses).to be_empty
+    expect_violation(<<-RUBY)
+      describe MyClass do
+        def method
+          include MyClass
+        end
+
+        class OtherClass
+          include MyClass
+        end
+
+        module MyModle
+          include MyClass
+        end
+      end
+    RUBY
   end
 
   it 'only takes class from top level describes' do
-    inspect_source(
-      cop,
-      [
-        'describe MyClass do',
-        '  describe MyClass::Foo do',
-        '    subject { MyClass::Foo }',
-        '    let(:foo) { MyClass }',
-        '  end',
-        'end'
-      ]
-    )
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.offenses.map(&:line).sort).to eq([4])
-    expect(cop.messages)
-      .to eq(['Use `described_class` instead of `MyClass`'])
-    expect(cop.highlights).to eq(['MyClass'])
+    expect_violation(<<-RUBY)
+      describe MyClass do
+        describe MyClass::Foo do
+          subject { MyClass::Foo }
+
+          let(:foo) { MyClass }
+                      ^^^^^^^ Use `described_class` instead of `MyClass`
+        end
+      end
+    RUBY
   end
 
   it 'ignores subclasses' do
-    inspect_source(
-      cop,
-      [
-        'describe MyClass do',
-        '  subject { MyClass::SubClass }',
-        'end'
-      ]
-    )
-    expect(cop.offenses).to be_empty
+    expect_violation(<<-RUBY)
+      describe MyClass do
+        subject { MyClass::SubClass }
+      end
+    RUBY
   end
 
   it 'ignores if namespace is not matching' do
-    inspect_source(
-      cop,
-      [
-        'describe MyNamespace::MyClass do',
-        '  subject { ::MyClass }',
-        '  let(:foo) { MyClass }',
-        'end'
-      ]
-    )
-    expect(cop.offenses).to be_empty
+    expect_violation(<<-RUBY)
+      describe MyNamespace::MyClass do
+        subject { ::MyClass }
+        let(:foo) { MyClass }
+      end
+    RUBY
   end
 
   it 'checks for the use of described class with namespace' do
-    inspect_source(
-      cop,
-      [
-        'describe MyNamespace::MyClass do',
-        '  subject { MyNamespace::MyClass }',
-        'end'
-      ]
-    )
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.offenses.map(&:line).sort).to eq([2])
-    expect(cop.messages)
-      .to eq(['Use `described_class` instead of `MyNamespace::MyClass`'])
-    expect(cop.highlights).to eq(['MyNamespace::MyClass'])
+    expect_violation(<<-RUBY)
+      describe MyNamespace::MyClass do
+        subject { MyNamespace::MyClass }
+                  ^^^^^^^^^^^^^^^^^^^^ Use `described_class` instead of `MyNamespace::MyClass`
+      end
+    RUBY
   end
 
   it 'does not flag violations within a scope change' do
-    inspect_source(
-      cop,
-      [
-        'describe MyNamespace::MyClass do',
-        '  before do',
-        '    class Foo',
-        '      thing = MyNamespace::MyClass.new',
-        '    end',
-        '  end',
-        'end'
-      ]
-    )
-
-    expect(cop.offenses).to be_empty
+    expect_violation(<<-RUBY)
+      describe MyNamespace::MyClass do
+        before do
+          class Foo
+            thing = MyNamespace::MyClass.new
+          end
+        end
+      end
+    RUBY
   end
 
   it 'does not flag violations within a scope change' do
-    inspect_source(
-      cop,
-      [
-        'describe do',
-        '  before do',
-        '    MyNamespace::MyClass.new',
-        '  end',
-        'end'
-      ]
-    )
-
-    expect(cop.offenses).to be_empty
+    expect_violation(<<-RUBY)
+      describe do
+        before do
+          MyNamespace::MyClass.new
+        end
+      end
+    RUBY
   end
 
   it 'checks for the use of described class with module' do
     skip
-    inspect_source(
-      lcop,
-      [
-        'module MyNamespace',
-        '  describe MyClass do',
-        '    subject { MyNamespace::MyClass }',
-        '  end',
-        'end'
-      ]
-    )
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.offenses.map(&:line).sort).to eq([2])
-    expect(cop.messages)
-      .to eq(['Use `described_class` instead of `MyNamespace::MyClass`'])
-    expect(cop.highlights).to eq(['MyNamespace::MyClass'])
+
+    expect_violation(<<-RUBY)
+      module MyNamespace
+        describe MyClass do
+          subject { MyNamespace::MyClass }
+                    ^^^^^^^^^^^^^^^^^^^^ Use `described_class` instead of `MyNamespace::MyClass`
+        end
+      end
+    RUBY
   end
 
   it 'autocorrects an offenses' do

--- a/spec/rubocop/cop/rspec/described_class_spec.rb
+++ b/spec/rubocop/cop/rspec/described_class_spec.rb
@@ -17,7 +17,7 @@ describe RuboCop::Cop::RSpec::DescribedClass do
   end
 
   it 'ignores described class as string' do
-    expect_violation(<<-RUBY)
+    expect_no_violations(<<-RUBY)
       describe MyClass do
         subject { "MyClass" }
       end
@@ -25,7 +25,7 @@ describe RuboCop::Cop::RSpec::DescribedClass do
   end
 
   it 'ignores describe that do not referece to a class' do
-    expect_violation(<<-RUBY)
+    expect_no_violations(<<-RUBY)
       describe "MyClass" do
         subject { "MyClass" }
       end
@@ -33,7 +33,7 @@ describe RuboCop::Cop::RSpec::DescribedClass do
   end
 
   it 'ignores class if the scope is changing' do
-    expect_violation(<<-RUBY)
+    expect_no_violations(<<-RUBY)
       describe MyClass do
         def method
           include MyClass
@@ -64,7 +64,7 @@ describe RuboCop::Cop::RSpec::DescribedClass do
   end
 
   it 'ignores subclasses' do
-    expect_violation(<<-RUBY)
+    expect_no_violations(<<-RUBY)
       describe MyClass do
         subject { MyClass::SubClass }
       end
@@ -72,7 +72,7 @@ describe RuboCop::Cop::RSpec::DescribedClass do
   end
 
   it 'ignores if namespace is not matching' do
-    expect_violation(<<-RUBY)
+    expect_no_violations(<<-RUBY)
       describe MyNamespace::MyClass do
         subject { ::MyClass }
         let(:foo) { MyClass }
@@ -90,7 +90,7 @@ describe RuboCop::Cop::RSpec::DescribedClass do
   end
 
   it 'does not flag violations within a scope change' do
-    expect_violation(<<-RUBY)
+    expect_no_violations(<<-RUBY)
       describe MyNamespace::MyClass do
         before do
           class Foo
@@ -102,7 +102,7 @@ describe RuboCop::Cop::RSpec::DescribedClass do
   end
 
   it 'does not flag violations within a scope change' do
-    expect_violation(<<-RUBY)
+    expect_no_violations(<<-RUBY)
       describe do
         before do
           MyNamespace::MyClass.new

--- a/spec/rubocop/cop/rspec/example_wording_spec.rb
+++ b/spec/rubocop/cop/rspec/example_wording_spec.rb
@@ -10,47 +10,38 @@ describe RuboCop::Cop::RSpec::ExampleWording, :config do
     end
 
     it 'ignores non-example blocks' do
-      inspect_source(cop, 'foo "should do something" do; end')
-      expect(cop.offenses).to be_empty
+      expect_violation('foo "should do something" do; end')
     end
 
     it 'finds description with `should` at the beginning' do
-      inspect_source(cop, ["it 'should do something' do", 'end'])
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.offenses.map(&:line).sort).to eq([1])
-      expect(cop.messages)
-        .to eq(['Do not use should when describing your tests.'])
-      expect(cop.highlights).to eq(['should do something'])
+      expect_violation(<<-RUBY)
+        it 'should do something' do
+            ^^^^^^^^^^^^^^^^^^^ Do not use should when describing your tests.
+        end
+      RUBY
     end
 
     it 'finds description with `Should` at the beginning' do
-      inspect_source(cop, ["it 'Should do something' do", 'end'])
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.offenses.map(&:line).sort).to eq([1])
-      expect(cop.messages)
-        .to eq(['Do not use should when describing your tests.'])
-      expect(cop.highlights).to eq(['Should do something'])
+      expect_violation(<<-RUBY)
+        it 'Should do something' do
+            ^^^^^^^^^^^^^^^^^^^ Do not use should when describing your tests.
+        end
+      RUBY
     end
 
     it 'finds description with `shouldn\'t` at the beginning' do
-      inspect_source(cop, ['it "shouldn\'t do something" do', 'end'])
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.offenses.map(&:line).sort).to eq([1])
-      expect(cop.messages)
-        .to eq(['Do not use should when describing your tests.'])
-      expect(cop.highlights).to eq(['shouldn\'t do something'])
+      expect_violation(<<-RUBY)
+        it "shouldn't do something" do
+            ^^^^^^^^^^^^^^^^^^^^^^ Do not use should when describing your tests.
+        end
+      RUBY
     end
 
     it 'skips descriptions without `should` at the beginning' do
-      inspect_source(
-        cop,
-        [
-          "it 'finds no should ' \\",
-          "   'here' do",
-          'end'
-        ]
-      )
-      expect(cop.offenses).to be_empty
+      expect_violation(<<-RUBY)
+        it 'finds no should here' do
+        end
+      RUBY
     end
 
     it 'corrects `it "should only have"` to it "only has"' do

--- a/spec/rubocop/cop/rspec/example_wording_spec.rb
+++ b/spec/rubocop/cop/rspec/example_wording_spec.rb
@@ -10,7 +10,7 @@ describe RuboCop::Cop::RSpec::ExampleWording, :config do
     end
 
     it 'ignores non-example blocks' do
-      expect_violation('foo "should do something" do; end')
+      expect_no_violations('foo "should do something" do; end')
     end
 
     it 'finds description with `should` at the beginning' do
@@ -38,7 +38,7 @@ describe RuboCop::Cop::RSpec::ExampleWording, :config do
     end
 
     it 'skips descriptions without `should` at the beginning' do
-      expect_violation(<<-RUBY)
+      expect_no_violations(<<-RUBY)
         it 'finds no should here' do
         end
       RUBY

--- a/spec/rubocop/cop/rspec/focus_spec.rb
+++ b/spec/rubocop/cop/rspec/focus_spec.rb
@@ -73,7 +73,7 @@ describe RuboCop::Cop::RSpec::Focus do
   end
 
   it 'does not flag unfocused specs' do
-    expect_violation(<<-RUBY)
+    expect_no_violations(<<-RUBY)
       xcontext      'test' do; end
       xscenario     'test' do; end
       xspecify      'test' do; end
@@ -101,7 +101,7 @@ describe RuboCop::Cop::RSpec::Focus do
   end
 
   it 'ignores non-rspec code with :focus blocks' do
-    expect_violation(<<-RUBY)
+    expect_no_violations(<<-RUBY)
       some_method "foo", focus: true do
       end
     RUBY

--- a/spec/rubocop/cop/rspec/focus_spec.rb
+++ b/spec/rubocop/cop/rspec/focus_spec.rb
@@ -1,78 +1,130 @@
 describe RuboCop::Cop::RSpec::Focus do
   subject(:cop) { described_class.new }
 
-  [
-    :example_group, :describe, :context, :xdescribe, :xcontext,
-    :it, :example, :specify, :xit, :xexample, :xspecify,
-    :feature, :scenario, :xfeature, :xscenario
-  ].each do |block_type|
-    it "finds `#{block_type}` blocks with `focus: true`" do
-      inspect_source(
-        cop,
-        [
-          "#{block_type} 'test', meta: true, focus: true do",
-          'end'
-        ]
-      )
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.offenses.map(&:line).sort).to eq([1])
-      expect(cop.messages).to eq(['Focused spec found.'])
-      expect(cop.highlights).to eq(['focus: true'])
-    end
+  # rubocop:disable RSpec/ExampleLength
+  it 'flags all rspec example blocks with that include `focus: true`' do
+    expect_violation(<<-RUBY)
+      example 'test', meta: true, focus: true do; end
+                                  ^^^^^^^^^^^ Focused spec found.
+      xit 'test', meta: true, focus: true do; end
+                              ^^^^^^^^^^^ Focused spec found.
+      describe 'test', meta: true, focus: true do; end
+                                   ^^^^^^^^^^^ Focused spec found.
+      it 'test', meta: true, focus: true do; end
+                             ^^^^^^^^^^^ Focused spec found.
+      xspecify 'test', meta: true, focus: true do; end
+                                   ^^^^^^^^^^^ Focused spec found.
+      specify 'test', meta: true, focus: true do; end
+                                  ^^^^^^^^^^^ Focused spec found.
+      example_group 'test', meta: true, focus: true do; end
+                                        ^^^^^^^^^^^ Focused spec found.
+      scenario 'test', meta: true, focus: true do; end
+                                   ^^^^^^^^^^^ Focused spec found.
+      xexample 'test', meta: true, focus: true do; end
+                                   ^^^^^^^^^^^ Focused spec found.
+      xdescribe 'test', meta: true, focus: true do; end
+                                    ^^^^^^^^^^^ Focused spec found.
+      context 'test', meta: true, focus: true do; end
+                                  ^^^^^^^^^^^ Focused spec found.
+      xcontext 'test', meta: true, focus: true do; end
+                                   ^^^^^^^^^^^ Focused spec found.
+      feature 'test', meta: true, focus: true do; end
+                                  ^^^^^^^^^^^ Focused spec found.
+      xfeature 'test', meta: true, focus: true do; end
+                                   ^^^^^^^^^^^ Focused spec found.
+      xscenario 'test', meta: true, focus: true do; end
+                                    ^^^^^^^^^^^ Focused spec found.
+    RUBY
+  end
 
-    it "finds `#{block_type}` blocks with `:focus`" do
-      inspect_source(
-        cop,
-        [
-          "#{block_type} 'test', :focus do",
-          'end'
-        ]
-      )
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.offenses.map(&:line).sort).to eq([1])
-      expect(cop.messages).to eq(['Focused spec found.'])
-      expect(cop.highlights).to eq([':focus'])
-    end
+  it 'flags all repec example blocks that include `:focus`' do
+    expect_violation(<<-RUBY)
+      example_group 'test', :focus do; end
+                            ^^^^^^ Focused spec found.
+      feature 'test', :focus do; end
+                      ^^^^^^ Focused spec found.
+      xexample 'test', :focus do; end
+                       ^^^^^^ Focused spec found.
+      xdescribe 'test', :focus do; end
+                        ^^^^^^ Focused spec found.
+      xscenario 'test', :focus do; end
+                        ^^^^^^ Focused spec found.
+      specify 'test', :focus do; end
+                      ^^^^^^ Focused spec found.
+      example 'test', :focus do; end
+                      ^^^^^^ Focused spec found.
+      xfeature 'test', :focus do; end
+                       ^^^^^^ Focused spec found.
+      xspecify 'test', :focus do; end
+                       ^^^^^^ Focused spec found.
+      scenario 'test', :focus do; end
+                       ^^^^^^ Focused spec found.
+      describe 'test', :focus do; end
+                       ^^^^^^ Focused spec found.
+      xit 'test', :focus do; end
+                  ^^^^^^ Focused spec found.
+      context 'test', :focus do; end
+                      ^^^^^^ Focused spec found.
+      xcontext 'test', :focus do; end
+                       ^^^^^^ Focused spec found.
+      it 'test', :focus do; end
+                 ^^^^^^ Focused spec found.
+    RUBY
+  end
 
-    it 'detects no offense when spec is not focused' do
-      inspect_source(
-        cop,
-        [
-          "#{block_type} 'test' do",
-          'end'
-        ]
-      )
-      expect(subject.messages).to be_empty
-    end
+  it 'does not flag unfocused specs' do
+    expect_violation(<<-RUBY)
+      xcontext      'test' do; end
+      xscenario     'test' do; end
+      xspecify      'test' do; end
+      describe      'test' do; end
+      example       'test' do; end
+      xexample      'test' do; end
+      scenario      'test' do; end
+      specify       'test' do; end
+      xit           'test' do; end
+      feature       'test' do; end
+      xfeature      'test' do; end
+      context       'test' do; end
+      it            'test' do; end
+      example_group 'test' do; end
+      xdescribe     'test' do; end
+    RUBY
   end
 
   it 'does not flag a method that is focused twice' do
-    inspect_source(cop, 'fit "foo", :focus do; end')
-    expect(cop.offenses.size).to be(1)
+    expect_violation(<<-RUBY)
+      fit "foo", :focus do
+      ^^^^^^^^^^^^^^^^^ Focused spec found.
+      end
+    RUBY
   end
 
   it 'ignores non-rspec code with :focus blocks' do
-    inspect_source(cop, 'some_method "foo", focus: true do; end')
-    expect(cop.offenses).to be_empty
+    expect_violation(<<-RUBY)
+      some_method "foo", focus: true do
+      end
+    RUBY
   end
 
-  [
-    :fdescribe, :fcontext,
-    :focus, :fexample, :fit, :fspecify,
-    :ffeature, :fscenario
-  ].each do |block_type|
-    it "finds `#{block_type}` blocks" do
-      inspect_source(
-        cop,
-        [
-          "#{block_type} 'test' do",
-          'end'
-        ]
-      )
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.offenses.map(&:line).sort).to eq([1])
-      expect(cop.messages).to eq(['Focused spec found.'])
-      expect(cop.highlights).to eq(["#{block_type} 'test'"])
-    end
+  it 'flags focused block types' do
+    expect_violation(<<-RUBY)
+      fdescribe 'test' do; end
+      ^^^^^^^^^^^^^^^^ Focused spec found.
+      ffeature 'test' do; end
+      ^^^^^^^^^^^^^^^ Focused spec found.
+      fcontext 'test' do; end
+      ^^^^^^^^^^^^^^^ Focused spec found.
+      fit 'test' do; end
+      ^^^^^^^^^^ Focused spec found.
+      fscenario 'test' do; end
+      ^^^^^^^^^^^^^^^^ Focused spec found.
+      fexample 'test' do; end
+      ^^^^^^^^^^^^^^^ Focused spec found.
+      fspecify 'test' do; end
+      ^^^^^^^^^^^^^^^ Focused spec found.
+      focus 'test' do; end
+      ^^^^^^^^^^^^ Focused spec found.
+    RUBY
   end
 end

--- a/spec/rubocop/cop/rspec/instance_variable_spec.rb
+++ b/spec/rubocop/cop/rspec/instance_variable_spec.rb
@@ -2,49 +2,37 @@ describe RuboCop::Cop::RSpec::InstanceVariable do
   subject(:cop) { described_class.new }
 
   it 'finds an instance variable inside a describe' do
-    inspect_source(
-      cop,
-      [
-        'describe MyClass do',
-        '  before { @foo = [] }',
-        '  it { expect(@foo).to be_empty }',
-        'end'
-      ]
-    )
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.offenses.map(&:line).sort).to eq([3])
-    expect(cop.messages).to eq(['Use `let` instead of an instance variable'])
+    expect_violation(<<-RUBY)
+      describe MyClass do
+        before { @foo = [] }
+        it { expect(@foo).to be_empty }
+                    ^^^^ Use `let` instead of an instance variable
+      end
+    RUBY
   end
 
   it 'ignores non-spec blocks' do
-    inspect_source(
-      cop,
-      [
-        'not_rspec do',
-        '  before { @foo = [] }',
-        '  it { expect(@foo).to be_empty }',
-        'end'
-      ]
-    )
-    expect(cop.offenses).to be_empty
+    expect_violation(<<-RUBY)
+      not_rspec do
+        before { @foo = [] }
+        it { expect(@foo).to be_empty }
+      end
+    RUBY
   end
 
   it 'finds an instance variable inside a shared example' do
-    inspect_source(
-      cop,
-      [
-        "shared_examples 'shared example' do",
-        '  it { expect(@foo).to be_empty }',
-        'end'
-      ]
-    )
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.offenses.map(&:line).sort).to eq([2])
-    expect(cop.messages).to eq(['Use `let` instead of an instance variable'])
+    expect_violation(<<-RUBY)
+      shared_examples 'shared example' do
+        it { expect(@foo).to be_empty }
+                    ^^^^ Use `let` instead of an instance variable
+      end
+    RUBY
   end
 
   it 'ignores an instance variable without describe' do
-    inspect_source(cop, ['@foo = []', '@foo.empty?'])
-    expect(cop.offenses).to be_empty
+    expect_violation(<<-RUBY)
+      @foo = []
+      @foo.empty?
+    RUBY
   end
 end

--- a/spec/rubocop/cop/rspec/instance_variable_spec.rb
+++ b/spec/rubocop/cop/rspec/instance_variable_spec.rb
@@ -12,7 +12,7 @@ describe RuboCop::Cop::RSpec::InstanceVariable do
   end
 
   it 'ignores non-spec blocks' do
-    expect_violation(<<-RUBY)
+    expect_no_violations(<<-RUBY)
       not_rspec do
         before { @foo = [] }
         it { expect(@foo).to be_empty }
@@ -30,7 +30,7 @@ describe RuboCop::Cop::RSpec::InstanceVariable do
   end
 
   it 'ignores an instance variable without describe' do
-    expect_violation(<<-RUBY)
+    expect_no_violations(<<-RUBY)
       @foo = []
       @foo.empty?
     RUBY

--- a/spec/rubocop/cop/rspec/multiple_describes_spec.rb
+++ b/spec/rubocop/cop/rspec/multiple_describes_spec.rb
@@ -2,42 +2,27 @@ describe RuboCop::Cop::RSpec::MultipleDescribes do
   subject(:cop) { described_class.new }
 
   it 'finds multiple top level describes with class and method' do
-    inspect_source(
-      cop,
-      [
-        "describe MyClass, '.do_something' do; end",
-        "describe MyClass, '.do_something_else' do; end"
-      ]
-    )
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.offenses.map(&:line).sort).to eq([1])
-    expect(cop.messages).to eq(['Do not use multiple top level describes - ' \
-                                'try to nest them.'])
+    expect_violation(<<-RUBY)
+      describe MyClass, '.do_something' do; end
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use multiple top level describes - try to nest them.
+      describe MyClass, '.do_something_else' do; end
+    RUBY
   end
 
   it 'finds multiple top level describes only with class' do
-    inspect_source(
-      cop,
-      [
-        'describe MyClass do; end',
-        'describe MyOtherClass do; end'
-      ]
-    )
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.offenses.map(&:line).sort).to eq([1])
-    expect(cop.messages).to eq(['Do not use multiple top level describes - ' \
-                                'try to nest them.'])
+    expect_violation(<<-RUBY)
+      describe MyClass do; end
+      ^^^^^^^^^^^^^^^^ Do not use multiple top level describes - try to nest them.
+      describe MyOtherClass do; end
+    RUBY
   end
 
   it 'skips single top level describe' do
-    inspect_source(
-      cop,
-      [
-        "require 'spec_helper'",
-        '',
-        'describe MyClass do; end'
-      ]
-    )
-    expect(cop.offenses).to be_empty
+    expect_violation(<<-RUBY)
+      require 'spec_helper'
+
+      describe MyClass do
+      end
+    RUBY
   end
 end

--- a/spec/rubocop/cop/rspec/multiple_describes_spec.rb
+++ b/spec/rubocop/cop/rspec/multiple_describes_spec.rb
@@ -18,7 +18,7 @@ describe RuboCop::Cop::RSpec::MultipleDescribes do
   end
 
   it 'skips single top level describe' do
-    expect_violation(<<-RUBY)
+    expect_no_violations(<<-RUBY)
       require 'spec_helper'
 
       describe MyClass do

--- a/spec/rubocop/cop/rspec/not_to_not_spec.rb
+++ b/spec/rubocop/cop/rspec/not_to_not_spec.rb
@@ -5,17 +5,16 @@ describe RuboCop::Cop::RSpec::NotToNot, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'not_to' } }
 
     it 'detects the `to_not` offense' do
-      inspect_source(subject, 'it { expect(false).to_not be_true }')
-
-      expect(subject.messages).to eq(['Prefer `not_to` over `to_not`'])
-      expect(subject.highlights).to eq(['expect(false).to_not be_true'])
-      expect(subject.offenses.map(&:line).sort).to eq([1])
+      expect_violation(<<-RUBY)
+        it { expect(false).to_not be_true }
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `not_to` over `to_not`
+      RUBY
     end
 
     it 'detects no offense when using `not_to`' do
-      inspect_source(subject, 'it { expect(false).not_to be_true }')
-
-      expect(subject.messages).to be_empty
+      expect_violation(<<-RUBY)
+        it { expect(false).not_to be_true }
+      RUBY
     end
 
     it 'auto-corrects `to_not` to `not_to`' do
@@ -28,17 +27,16 @@ describe RuboCop::Cop::RSpec::NotToNot, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'to_not' } }
 
     it 'detects the `not_to` offense' do
-      inspect_source(subject, 'it { expect(false).not_to be_true }')
-
-      expect(subject.messages).to eq(['Prefer `to_not` over `not_to`'])
-      expect(subject.highlights).to eq(['expect(false).not_to be_true'])
-      expect(subject.offenses.map(&:line).sort).to eq([1])
+      expect_violation(<<-RUBY)
+        it { expect(false).not_to be_true }
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `to_not` over `not_to`
+      RUBY
     end
 
     it 'detects no offense when using `to_not`' do
-      inspect_source(subject, 'it { expect(false).to_not be_true }')
-
-      expect(subject.messages).to be_empty
+      expect_violation(<<-RUBY)
+        it { expect(false).to_not be_true }
+      RUBY
     end
 
     it 'auto-corrects `not_to` to `to_not`' do

--- a/spec/rubocop/cop/rspec/not_to_not_spec.rb
+++ b/spec/rubocop/cop/rspec/not_to_not_spec.rb
@@ -12,7 +12,7 @@ describe RuboCop::Cop::RSpec::NotToNot, :config do
     end
 
     it 'detects no offense when using `not_to`' do
-      expect_violation(<<-RUBY)
+      expect_no_violations(<<-RUBY)
         it { expect(false).not_to be_true }
       RUBY
     end
@@ -34,7 +34,7 @@ describe RuboCop::Cop::RSpec::NotToNot, :config do
     end
 
     it 'detects no offense when using `to_not`' do
-      expect_violation(<<-RUBY)
+      expect_no_violations(<<-RUBY)
         it { expect(false).to_not be_true }
       RUBY
     end

--- a/spec/rubocop/cop/rspec/verified_doubles_spec.rb
+++ b/spec/rubocop/cop/rspec/verified_doubles_spec.rb
@@ -2,39 +2,33 @@ describe RuboCop::Cop::RSpec::VerifiedDoubles, :config do
   subject(:cop) { described_class.new(config) }
 
   it 'finds a `double` instead of an `instance_double`' do
-    inspect_source(cop, ['it do',
-                         '  foo = double("Widget")',
-                         'end'])
-    expect(cop.messages)
-      .to eq(['Prefer using verifying doubles over normal doubles.'])
-    expect(cop.highlights).to eq(['double("Widget")'])
-    expect(cop.offenses.map(&:line).sort).to eq([2])
-    expect(cop.offenses.map(&:to_s).sort).to all(
-      eql('C:  2:  9: Prefer using verifying doubles over normal doubles.')
-    )
+    expect_violation(<<-RUBY)
+      it do
+        foo = double("Widget")
+              ^^^^^^^^^^^^^^^^ Prefer using verifying doubles over normal doubles.
+      end
+    RUBY
   end
 
   context 'when configuration does not specify IgnoreSymbolicNames' do
     let(:cop_config) { Hash.new }
 
     it 'find doubles whose name is a symbol' do
-      inspect_source(cop, ['it do',
-                           '  foo = double(:widget)',
-                           'end'])
-      expect(cop.messages)
-        .to eq(['Prefer using verifying doubles over normal doubles.'])
-      expect(cop.highlights).to eq(['double(:widget)'])
-      expect(cop.offenses.map(&:line).sort).to eq([2])
+      expect_violation(<<-RUBY)
+        it do
+          foo = double(:widget)
+                ^^^^^^^^^^^^^^^ Prefer using verifying doubles over normal doubles.
+        end
+      RUBY
     end
 
     it 'finds a `spy` instead of an `instance_spy`' do
-      inspect_source(cop, ['it do',
-                           '  foo = spy("Widget")',
-                           'end'])
-      expect(cop.messages)
-        .to eq(['Prefer using verifying doubles over normal doubles.'])
-      expect(cop.highlights).to eq(['spy("Widget")'])
-      expect(cop.offenses.map(&:line).sort).to eq([2])
+      expect_violation(<<-RUBY)
+        it do
+          foo = spy("Widget")
+                ^^^^^^^^^^^^^ Prefer using verifying doubles over normal doubles.
+        end
+      RUBY
     end
   end
 
@@ -42,34 +36,36 @@ describe RuboCop::Cop::RSpec::VerifiedDoubles, :config do
     let(:cop_config) { { 'IgnoreSymbolicNames' => true } }
 
     it 'ignores doubles whose name is a symbol' do
-      inspect_source(cop, ['it do',
-                           '  foo = double(:widget)',
-                           'end'])
-      expect(cop.messages).to be_empty
+      expect_violation(<<-RUBY)
+        it do
+          foo = double(:widget)
+        end
+      RUBY
     end
 
     it 'still flags doubles whose name is a string' do
-      inspect_source(cop, ['it do',
-                           '  foo = double("widget")',
-                           'end'])
-
-      expect(cop.messages.first).to eq(
-        'Prefer using verifying doubles over normal doubles.'
-      )
+      expect_violation(<<-RUBY)
+        it do
+          foo = double("widget")
+                ^^^^^^^^^^^^^^^^ Prefer using verifying doubles over normal doubles.
+        end
+      RUBY
     end
   end
 
   it 'ignores doubles without a name' do
-    inspect_source(cop, ['it do',
-                         '  foo = double',
-                         'end'])
-    expect(cop.messages).to be_empty
+    expect_violation(<<-RUBY)
+      it do
+        foo = double
+      end
+    RUBY
   end
 
   it 'ignores instance_doubles' do
-    inspect_source(cop, ['it do',
-                         '  foo = instance_double("Foo")',
-                         'end'])
-    expect(cop.messages).to be_empty
+    expect_violation(<<-RUBY)
+      it do
+        foo = instance_double("Foo")
+      end
+    RUBY
   end
 end

--- a/spec/rubocop/cop/rspec/verified_doubles_spec.rb
+++ b/spec/rubocop/cop/rspec/verified_doubles_spec.rb
@@ -36,7 +36,7 @@ describe RuboCop::Cop::RSpec::VerifiedDoubles, :config do
     let(:cop_config) { { 'IgnoreSymbolicNames' => true } }
 
     it 'ignores doubles whose name is a symbol' do
-      expect_violation(<<-RUBY)
+      expect_no_violations(<<-RUBY)
         it do
           foo = double(:widget)
         end
@@ -54,7 +54,7 @@ describe RuboCop::Cop::RSpec::VerifiedDoubles, :config do
   end
 
   it 'ignores doubles without a name' do
-    expect_violation(<<-RUBY)
+    expect_no_violations(<<-RUBY)
       it do
         foo = double
       end
@@ -62,7 +62,7 @@ describe RuboCop::Cop::RSpec::VerifiedDoubles, :config do
   end
 
   it 'ignores instance_doubles' do
-    expect_violation(<<-RUBY)
+    expect_no_violations(<<-RUBY)
       it do
         foo = instance_double("Foo")
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,8 @@ if ENV['CI']
   CodeClimate::TestReporter.start
 end
 
+Dir.glob(File.expand_path('support/*.rb', __dir__)).map(&method(:require))
+
 RSpec.configure do |config|
   config.order = :random
 
@@ -17,8 +19,11 @@ RSpec.configure do |config|
   config.mock_with :rspec do |mocks|
     mocks.syntax = :expect # Disable `should_receive` and `stub`
   end
+
+  config.include(ExpectViolation)
 end
 
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
+
 require 'rubocop-rspec'

--- a/spec/support/expect_violation.rb
+++ b/spec/support/expect_violation.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+require 'adamantium'
+require 'concord'
+require 'anima'
+
+module ExpectViolation
+  DEFAULT_FILENAME = 'example_spec.rb'.freeze
+
+  def expect_violation(source, filename: DEFAULT_FILENAME)
+    expectation = Expectation.new(source)
+    inspect_source(cop, expectation.source, filename)
+    offenses = cop.offenses.map(&method(:to_assertion)).sort
+    expect(offenses).to eq(expectation.assertions.sort)
+  end
+
+  private
+
+  def to_assertion(offense)
+    Expectation::Assertion.new(
+      message:      offense.message,
+      line_number:  offense.location.line,
+      column_range: offense.location.column_range
+    )
+  end
+
+  class Expectation
+    VIOLATION_LINE_PATTERN = /\A *\^/
+
+    VIOLATION = :violation
+    SOURCE    = :line
+
+    include Adamantium, Concord.new(:string)
+
+    def source
+      source_map.to_s
+    end
+
+    def assertions
+      source_map.assertions
+    end
+
+    private
+
+    def source_map
+      tokens.reduce(Source::BLANK) do |source, (type, tokens)|
+        tokens.reduce(source, :"add_#{type}")
+      end
+    end
+    memoize :source_map
+
+    def tokens
+      string.each_line.chunk do |line|
+        next SOURCE unless line =~ VIOLATION_LINE_PATTERN
+
+        VIOLATION
+      end
+    end
+
+    class Source
+      include Concord.new(:lines)
+
+      BLANK = new([].freeze)
+
+      def add_line(line)
+        self.class.new(lines + [Line.new(text: line, number: lines.size + 1)])
+      end
+
+      def add_violation(violation)
+        self.class.new([*lines[0...-1], lines.last.add_violation(violation)])
+      end
+
+      def to_s
+        lines.map(&:text).join
+      end
+
+      def assertions
+        lines.flat_map(&:assertions)
+      end
+
+      class Line
+        DEFAULTS = { violations: [] }.freeze
+
+        include Anima.new(:text, :number, :violations)
+
+        def initialize(options)
+          super(DEFAULTS.merge(options))
+        end
+
+        def add_violation(violation)
+          with(violations: violations + [violation])
+        end
+
+        def assertions
+          violations.map do |violation|
+            Assertion.parse(
+              text:        violation,
+              line_number: number
+            )
+          end
+        end
+      end
+    end
+
+    class Assertion
+      def self.parse(text:, line_number:)
+        parser = Parser.new(text)
+
+        new(
+          message:      parser.message,
+          column_range: parser.column_range,
+          line_number:  line_number
+        )
+      end
+
+      include Anima.new(:message, :column_range, :line_number),
+              Adamantium,
+              Comparable
+
+      def <=>(other)
+        to_a <=> other.to_a
+      end
+
+      protected
+
+      def to_a
+        [line_number, column_range.first, column_range.last, message]
+      end
+
+      class Parser
+        COLUMN_PATTERN = /^ *(?<carets>\^\^*) (?<message>.+)$/
+
+        include Concord.new(:text), Adamantium
+
+        def column_range
+          Range.new(*match.offset(:carets), true)
+        end
+
+        def message
+          match[:message]
+        end
+
+        private
+
+        def match
+          text.match(COLUMN_PATTERN)
+        end
+        memoize :match
+      end
+
+      private_constant(*constants(false))
+    end
+  end
+end

--- a/spec/support/expect_violation.rb
+++ b/spec/support/expect_violation.rb
@@ -7,11 +7,23 @@ require 'anima'
 module ExpectViolation
   DEFAULT_FILENAME = 'example_spec.rb'.freeze
 
+  # rubocop:disable Metrics/AbcSize
   def expect_violation(source, filename: DEFAULT_FILENAME)
     expectation = Expectation.new(source)
     inspect_source(cop, expectation.source, filename)
     offenses = cop.offenses.map(&method(:to_assertion)).sort
+
+    if expectation.assertions.empty?
+      raise 'Use expect_no_violations to assert no violations'
+    end
+
     expect(offenses).to eq(expectation.assertions.sort)
+  end
+
+  def expect_no_violations(source, filename: DEFAULT_FILENAME)
+    inspect_source(cop, source, filename)
+
+    expect(cop.offenses.empty?).to be(true)
   end
 
   private


### PR DESCRIPTION
Allows for more clear, easy to write, and strict specs:

## Before

```ruby
describe RuboCop::Cop::RSpec::VerifiedDoubles, :config do
  subject(:cop) { described_class.new(config) }

  it 'finds a `double` instead of an `instance_double`' do
    inspect_source(cop, ['it do',
                         '  foo = double("Widget")',
                         'end'])
    expect(cop.messages)
      .to eq(['Prefer using verifying doubles over normal doubles.'])
    expect(cop.highlights).to eq(['double("Widget")'])
    expect(cop.offenses.map(&:line).sort).to eq([2])
    expect(cop.offenses.map(&:to_s).sort).to all(
      eql('C:  2:  9: Prefer using verifying doubles over normal doubles.')
    )
  end

  context 'when configuration does not specify IgnoreSymbolicNames' do
    let(:cop_config) { Hash.new }

    it 'find doubles whose name is a symbol' do
      inspect_source(cop, ['it do',
                           '  foo = double(:widget)',
                           'end'])
      expect(cop.messages)
        .to eq(['Prefer using verifying doubles over normal doubles.'])
      expect(cop.highlights).to eq(['double(:widget)'])
      expect(cop.offenses.map(&:line).sort).to eq([2])
    end

    it 'finds a `spy` instead of an `instance_spy`' do
      inspect_source(cop, ['it do',
                           '  foo = spy("Widget")',
                           'end'])
      expect(cop.messages)
        .to eq(['Prefer using verifying doubles over normal doubles.'])
      expect(cop.highlights).to eq(['spy("Widget")'])
      expect(cop.offenses.map(&:line).sort).to eq([2])
    end
  end

  context 'when configured to ignore symbolic names' do
    let(:cop_config) { { 'IgnoreSymbolicNames' => true } }

    it 'ignores doubles whose name is a symbol' do
      inspect_source(cop, ['it do',
                           '  foo = double(:widget)',
                           'end'])
      expect(cop.messages).to be_empty
    end

    it 'still flags doubles whose name is a string' do
      inspect_source(cop, ['it do',
                           '  foo = double("widget")',
                           'end'])

      expect(cop.messages.first).to eq(
        'Prefer using verifying doubles over normal doubles.'
      )
    end
  end

  it 'ignores doubles without a name' do
    inspect_source(cop, ['it do',
                         '  foo = double',
                         'end'])
    expect(cop.messages).to be_empty
  end

  it 'ignores instance_doubles' do
    inspect_source(cop, ['it do',
                         '  foo = instance_double("Foo")',
                         'end'])
    expect(cop.messages).to be_empty
  end
end
```

## After

```ruby
describe RuboCop::Cop::RSpec::VerifiedDoubles, :config do
  subject(:cop) { described_class.new(config) }

  it 'finds a `double` instead of an `instance_double`' do
    expect_violation(<<-RUBY)
      it do
        foo = double("Widget")
              ^^^^^^^^^^^^^^^^ Prefer using verifying doubles over normal doubles.
      end
    RUBY
  end

  context 'when configuration does not specify IgnoreSymbolicNames' do
    let(:cop_config) { Hash.new }

    it 'find doubles whose name is a symbol' do
      expect_violation(<<-RUBY)
        it do
          foo = double(:widget)
                ^^^^^^^^^^^^^^^ Prefer using verifying doubles over normal doubles.
        end
      RUBY
    end

    it 'finds a `spy` instead of an `instance_spy`' do
      expect_violation(<<-RUBY)
        it do
          foo = spy("Widget")
                ^^^^^^^^^^^^^ Prefer using verifying doubles over normal doubles.
        end
      RUBY
    end
  end

  context 'when configured to ignore symbolic names' do
    let(:cop_config) { { 'IgnoreSymbolicNames' => true } }

    it 'ignores doubles whose name is a symbol' do
      expect_no_violations(<<-RUBY)
        it do
          foo = double(:widget)
        end
      RUBY
    end

    it 'still flags doubles whose name is a string' do
      expect_violation(<<-RUBY)
        it do
          foo = double("widget")
                ^^^^^^^^^^^^^^^^ Prefer using verifying doubles over normal doubles.
        end
      RUBY
    end
  end

  it 'ignores doubles without a name' do
    expect_no_violations(<<-RUBY)
      it do
        foo = double
      end
    RUBY
  end

  it 'ignores instance_doubles' do
    expect_no_violations(<<-RUBY)
      it do
        foo = instance_double("Foo")
      end
    RUBY
  end
end
```