### PR TITLE
Add SkipBlocks option for DescribedClass cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (unreleased)
 
+* Add `SkipBlocks` option for `DescribedClass` cop. ([@backus][])
+
 ## 1.5.3 (2016-08-02)
 
 * Add `RSpec/NamedSubject` cop. ([@backus][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -8,6 +8,7 @@ RSpec/DescribeClass:
 
 RSpec/DescribedClass:
   Description: 'Use `described_class` for tested class / module'
+  SkipBlocks: false
   Enabled: true
 
 RSpec/DescribeMethod:

--- a/lib/rubocop/cop/rspec/described_class.rb
+++ b/lib/rubocop/cop/rspec/described_class.rb
@@ -30,7 +30,15 @@ module RuboCop
             (args) $_)
         PATTERN
 
-        def_node_matcher :scope_change?, '{def class module}'
+        def_node_matcher :scope_changing_syntax?, '{def class module}'
+
+        def_node_matcher :common_instance_exec_closure?, <<-PATTERN
+          (block
+            (send
+              (const nil {:Class :Module}) :new
+              ...)
+            ...)
+        PATTERN
 
         def on_block(node)
           describe, described_class, body = described_constant(node)
@@ -58,6 +66,10 @@ module RuboCop
           node.children.each do |child|
             find_constant_usage(child, described_class, &block)
           end
+        end
+
+        def scope_change?(node)
+          scope_changing_syntax?(node) || common_instance_exec_closure?(node)
         end
       end
     end

--- a/lib/rubocop/cop/rspec/described_class.rb
+++ b/lib/rubocop/cop/rspec/described_class.rb
@@ -20,41 +20,44 @@ module RuboCop
       class DescribedClass < Cop
         include RuboCop::RSpec::TopLevelDescribe
 
-        MESSAGE = 'Use `described_class` instead of `%s`'.freeze
+        DESCRIBED_CLASS = 'described_class'.freeze
+        MSG             = "Use `#{DESCRIBED_CLASS}` instead of `%s`".freeze
+
+        def_node_matcher :described_constant, <<-PATTERN
+          (block
+            $(send _ :describe
+              $(const ...))
+            (args) $_)
+        PATTERN
+
+        def_node_matcher :scope_change?, '{def class module}'
 
         def on_block(node)
-          method, _args, body = *node
-          return unless top_level_describe?(method)
+          describe, described_class, body = described_constant(node)
+          return unless top_level_describe?(describe)
 
-          _receiver, _method_name, object = *method
-          return unless object && object.type.equal?(:const)
-
-          inspect_children(body, object)
+          find_constant_usage(body, described_class) do |match|
+            add_offense(match, :expression, format(MSG, match.const_name))
+          end
         end
 
         def autocorrect(node)
           lambda do |corrector|
-            corrector.replace(node.loc.expression, 'described_class')
+            corrector.replace(node.loc.expression, DESCRIBED_CLASS)
           end
         end
 
         private
 
-        def inspect_children(node, object)
+        def find_constant_usage(node, described_class, &block)
+          yield(node) if node.eql?(described_class)
+
           return unless node.instance_of?(Node)
-          return if scope_change?(node) || node.type.equal?(:const)
+          return if scope_change?(node) || node.const_type?
 
           node.children.each do |child|
-            if child.eql?(object)
-              name = object.loc.expression.source
-              add_offense(child, :expression, format(MESSAGE, name))
-            end
-            inspect_children(child, object)
+            find_constant_usage(child, described_class, &block)
           end
-        end
-
-        def scope_change?(node)
-          [:def, :class, :module].include?(node.type)
         end
       end
     end

--- a/spec/rubocop/cop/rspec/described_class_spec.rb
+++ b/spec/rubocop/cop/rspec/described_class_spec.rb
@@ -35,6 +35,9 @@ describe RuboCop::Cop::RSpec::DescribedClass do
   it 'ignores class if the scope is changing' do
     expect_no_violations(<<-RUBY)
       describe MyClass do
+        Class.new  { foo = MyClass }
+        Module.new { bar = MyClass }
+
         def method
           include MyClass
         end

--- a/spec/rubocop/cop/rspec/described_class_spec.rb
+++ b/spec/rubocop/cop/rspec/described_class_spec.rb
@@ -1,5 +1,73 @@
-describe RuboCop::Cop::RSpec::DescribedClass do
-  subject(:cop) { described_class.new }
+describe RuboCop::Cop::RSpec::DescribedClass, :config do
+  subject(:cop) { described_class.new(config) }
+
+  shared_examples 'SkipBlocks enabled' do
+    it 'does not flag violations within non-rspec blocks' do
+      expect_violation(<<-RUBY)
+        describe MyClass do
+          controller(ApplicationController) do
+            bar = MyClass
+          end
+
+          before do
+            MyClass
+            ^^^^^^^ Use `described_class` instead of `MyClass`
+
+            Foo.custom_block do
+              MyClass
+            end
+          end
+        end
+      RUBY
+    end
+  end
+
+  shared_examples 'SkipBlocks disabled' do
+    it 'flags violations within all blocks' do
+      expect_violation(<<-RUBY)
+        describe MyClass do
+          controller(ApplicationController) do
+            bar = MyClass
+                  ^^^^^^^ Use `described_class` instead of `MyClass`
+          end
+
+          before(:each) do
+            MyClass
+            ^^^^^^^ Use `described_class` instead of `MyClass`
+
+            Foo.custom_block do
+              MyClass
+              ^^^^^^^ Use `described_class` instead of `MyClass`
+            end
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when SkipBlocks is `true`' do
+    let(:cop_config) { { 'SkipBlocks' => true } }
+
+    include_examples 'SkipBlocks enabled'
+  end
+
+  context 'when SkipBlocks anything besides `true`' do
+    let(:cop_config) { { 'SkipBlocks' => 'yes' } }
+
+    include_examples 'SkipBlocks disabled'
+  end
+
+  context 'when SkipBlocks is not set' do
+    let(:cop_config) { Hash.new }
+
+    include_examples 'SkipBlocks disabled'
+  end
+
+  context 'when SkipBlocks is `false`' do
+    let(:cop_config) { { 'SkipBlocks' => false } }
+
+    include_examples 'SkipBlocks disabled'
+  end
 
   it 'checks for the use of the described class' do
     expect_violation(<<-RUBY)


### PR DESCRIPTION
Now the following code will **never** be flagged:

```ruby
describe MyClass do
  Class.new  { foo = MyClass }
  Module.new { bar = MyClass }
end
```

With the `SkipBlocks` option enabled the following code would receive the following flags:

```ruby
describe MyClass do
  controller(ApplicationController) do
    bar = MyClass
  end

  before do
    MyClass
    ^^^^^^^ Use `described_class` instead of `MyClass`

    Foo.custom_block do
      MyClass
    end
  end
end
```

With `SkipBlocks` disabled (the default option) the code would receive the following flags:

```ruby
describe MyClass do
  controller(ApplicationController) do
    bar = MyClass
          ^^^^^^^ Use `described_class` instead of `MyClass`
  end

  before(:each) do
    MyClass
    ^^^^^^^ Use `described_class` instead of `MyClass`

    Foo.custom_block do
      MyClass
      ^^^^^^^ Use `described_class` instead of `MyClass`
    end
  end
end
```