### PR TITLE
Better alphanumeric handling in file path cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (unreleased)
 
 * Optinally ignore method names in the `describe` argument when running the `FilePath` cop. ([@bquorning][])
+* Fix regression in how `FilePath` converts alphanumeric class names into paths. ([@bquorning][])
 
 ## 1.7.0 (2016-08-24)
 

--- a/lib/rubocop/cop/rspec/file_path.rb
+++ b/lib/rubocop/cop/rspec/file_path.rb
@@ -89,8 +89,8 @@ module RuboCop
 
         def camel_to_underscore(string)
           string
-            .gsub(/([^A-Z])([A-Z]+)/, '\\1_\\2')
-            .gsub(/([A-Z])([A-Z\d][^A-Z\d]+)/, '\\1_\\2')
+            .gsub(/([^A-Z])([A-Z]+)/, '\1_\2')
+            .gsub(/([A-Z])([A-Z\d][^A-Z\d]+)/, '\1_\2')
             .downcase
         end
 

--- a/lib/rubocop/cop/rspec/file_path.rb
+++ b/lib/rubocop/cop/rspec/file_path.rb
@@ -90,7 +90,7 @@ module RuboCop
         def camel_to_underscore(string)
           string
             .gsub(/([^A-Z])([A-Z]+)/, '\1_\2')
-            .gsub(/([A-Z])([A-Z\d][^A-Z\d]+)/, '\1_\2')
+            .gsub(/([A-Z])([A-Z][^A-Z\d]+)/, '\1_\2')
             .downcase
         end
 

--- a/spec/rubocop/cop/rspec/file_path_spec.rb
+++ b/spec/rubocop/cop/rspec/file_path_spec.rb
@@ -116,8 +116,8 @@ describe RuboCop::Cop::RSpec::FilePath, :config do
   it 'handles alphanumeric class names' do
     inspect_source(
       cop,
-      'describe IPv4AndIPv6 do; end',
-      'i_pv4_and_i_pv6_spec.rb'
+      'describe IPV4AndIPV6 do; end',
+      'ipv4_and_ipv6_spec.rb'
     )
     expect(cop.offenses).to be_empty
   end


### PR DESCRIPTION
The `FilePath` cop was changed to better handle alphanumeric class names in #88, but that feature was removed again in #135 (I assume by accident) – see my comment in https://github.com/nevir/rubocop-rspec/pull/135/files#r77190937

This PR improves the situation, specifically where class names contains a capital letter followed by a digit.