### PR TITLE
Optionally ignore methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (unreleased)
 
+* Optinally ignore method names in the `describe` argument when running the `FilePath` cop. ([@bquorning][])
+
 ## 1.7.0 (2016-08-24)
 
 * Add support for checking all example groups with `ExampleLength`. ([@backus][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -90,6 +90,7 @@ RSpec/FilePath:
   CustomTransform:
     RuboCop: rubocop
     RSpec: rspec
+  IgnoreMethods: false
 
 RSpec/VerifiedDoubles:
   Description: Prefer using verifying doubles over normal doubles.

--- a/lib/rubocop/cop/rspec/file_path.rb
+++ b/lib/rubocop/cop/rspec/file_path.rb
@@ -20,7 +20,6 @@ module RuboCop
         include RuboCop::RSpec::SpecOnly, RuboCop::RSpec::TopLevelDescribe
 
         MESSAGE = 'Spec path should end with `%s`'.freeze
-        METHOD_STRING_MATCHER = /^[\#\.].+/
         ROUTING_PAIR = s(:pair, s(:sym, :type), s(:sym, :routing))
 
         def on_top_level_describe(node, args)

--- a/lib/rubocop/cop/rspec/file_path.rb
+++ b/lib/rubocop/cop/rspec/file_path.rb
@@ -8,14 +8,39 @@ module RuboCop
       # Checks the path of the spec file and enforces that it reflects the
       # described class/module and its optionally called out method.
       #
+      # With the configuration option `IgnoreMethods` the called out method will
+      # be ignored when determining the enforced path.
+      #
       # With the configuration option `CustomTransform` modules or classes can
       # be specified that should not as usual be transformed from CamelCase to
       # snake_case (e.g. 'RuboCop' => 'rubocop' ).
       #
       # @example
-      #   my_class/method_spec.rb  # describe MyClass, '#method'
-      #   my_class_method_spec.rb  # describe MyClass, '#method'
+      #   # bad
+      #   whatever_spec.rb         # describe MyClass
+      #
+      #   # bad
+      #   my_class_spec.rb         # describe MyClass, '#method'
+      #
+      #   # good
       #   my_class_spec.rb         # describe MyClass
+      #
+      #   # good
+      #   my_class_method_spec.rb  # describe MyClass, '#method'
+      #
+      #   # good
+      #   my_class/method_spec.rb  # describe MyClass, '#method'
+      #
+      # @example when configuration is `IgnoreMethods: true`
+      #   # bad
+      #   whatever_spec.rb         # describe MyClass
+      #
+      #   # good
+      #   my_class_spec.rb         # describe MyClass
+      #
+      #   # good
+      #   my_class_spec.rb         # describe MyClass, '#method'
+      #
       class FilePath < Cop
         include RuboCop::RSpec::SpecOnly, RuboCop::RSpec::TopLevelDescribe
 
@@ -45,7 +70,7 @@ module RuboCop
 
         def matcher(object, method)
           path = File.join(parts(object))
-          if method && method.type.equal?(:str)
+          if method && method.type.equal?(:str) && !ignore_methods?
             path += '*' + method.str_content.gsub(/\W+/, '')
           end
 
@@ -71,6 +96,10 @@ module RuboCop
 
         def regexp_from_glob(glob)
           Regexp.new(glob.sub('.', '\\.').gsub('*', '.*') + '$')
+        end
+
+        def ignore_methods?
+          cop_config['IgnoreMethods']
         end
 
         def custom_transform

--- a/spec/rubocop/cop/rspec/file_path_spec.rb
+++ b/spec/rubocop/cop/rspec/file_path_spec.rb
@@ -212,7 +212,7 @@ describe RuboCop::Cop::RSpec::FilePath, :config do
     expect(cop.offenses).to be_empty
   end
 
-  context 'when configured' do
+  context 'when configured with CustomTransform' do
     let(:cop_config) { { 'CustomTransform' => { 'FooFoo' => 'foofoo' } } }
 
     it 'respects custom module name transformation' do
@@ -229,6 +229,19 @@ describe RuboCop::Cop::RSpec::FilePath, :config do
         cop,
         'describe MyController, "#foo", type: :routing do; end',
         'foofoo/some/class/bar_spec.rb'
+      )
+      expect(cop.offenses).to be_empty
+    end
+  end
+
+  context 'when configured with IgnoreMethods' do
+    let(:cop_config) { { 'IgnoreMethods' => true } }
+
+    it 'does not care about the described method' do
+      inspect_source(
+        cop,
+        "describe MyClass, '#look_here_a_method' do; end",
+        'my_class_spec.rb'
       )
       expect(cop.offenses).to be_empty
     end


### PR DESCRIPTION
Personally I have never named a spec file after the name of the method it’s testing. Perhaps I’m a minority?

With this PR, I can configure `RSpec/FilePath` with `'IgnoreMethods' => true` and it will only look at the described class/module name when recommending a path for this spec file.